### PR TITLE
Fix to handle flags in argparse

### DIFF
--- a/bin/python.py
+++ b/bin/python.py
@@ -3,65 +3,35 @@ Simulates a console call to python -m module|file [args]
 
 Used for running standard library python modules such as:
 SimpleHTTPServer, unittest and .py files.
--b will run the module/file in the background
 
+Can also be used to run a script in the background, such as a server, with the bash character & at the end.
 usage:
-    python -m [-b] module_name [args]
-    python [-b] python_file.py [args]
+    python -m module_name [args]
+    python python_file.py [args]
 '''
 
 import runpy
 import sys
-import threading
 import ui
-import argparse
-
-
-class ModuleThread(threading.Thread):
-    
-    def __init__(self,module,name):
-        self.is_module = module
-        self.module_name = name
-        threading.Thread.__init__(self)
-    @ui.in_background    
-    def run(self):
-        try:
-            if self.is_module:
-                
-                runpy.run_module(self.module_name, run_name='__main__')
-            else:
-                runpy.run_path(self.module_name, run_name='__main__')
-        except Exception, e:
-            print e
-            
+import argparse            
 
 ap = argparse.ArgumentParser()
 ap.add_argument('-m', '--module', action='store_true', default=False, help='run module')
-ap.add_argument('-b', '--background', action='store_true', default=False, help='run as background thread')
 ap.add_argument('name', help='file or module name')
 ap.add_argument('args_to_pass', nargs=argparse.REMAINDER, help='args to pass')
 args = ap.parse_args()
 
-run_as_thread = args.background
-run_as_module = args.module
 module_name = str(args.name)
 
 sys.argv = [sys.argv[0]] + args.args_to_pass
 
-if run_as_module:
+if args.module:
     try:
-        #os.chdir('../..')
-        if run_as_thread:
-            ModuleThread(True,module_name).start()
-        else:
-            runpy.run_module(module_name, run_name='__main__')
+        runpy.run_module(module_name, run_name='__main__')
     except ImportError, e:
         print 'ImportError: '+str(e)
 else:
     try:
-        if run_as_thread:
-            ModuleThread(False,module_name).start()
-        else:
-            runpy.run_path(module_name, run_name='__main__')
+        runpy.run_path(module_name, run_name='__main__')
     except Exception, e:
         print 'Error: '+ str(e)


### PR DESCRIPTION
I didn't realize that argparse would have a problem with other passed flags. Had to manipulate sys.argv before passing it to argparse.

problem: python -b -m test.py -s some_arg. This fix allows -s to be passed to test.py without an argparse error.
