### PR TITLE
better error handling if current directory isn't a repository

### DIFF
--- a/bin/git.py
+++ b/bin/git.py
@@ -140,9 +140,13 @@ command_help={    'init':  'initialize a new Git repository'
 
 
     
-    #Find a git repo dir
+#Find a git repo dir
 def _find_repo(path):
-    subdirs = os.walk(path).next()[1]
+    try:
+        subdirs = os.walk(path).next()[1]
+    except StopIteration: # happens if path is not listable
+        return None
+        
     if '.git' in subdirs:
         return path
     else:
@@ -154,7 +158,10 @@ def _find_repo(path):
 
 #Get the parent git repo, if there is one
 def _get_repo():
-    return Gittle(_find_repo(os.getcwd()))
+    repo_dir = _find_repo(os.getcwd())
+    if not repo_dir:
+        raise Exception("Current directory isn't a git repository")
+    return Gittle(repo_dir)
 
 def _confirm_dangerous():
         repo = _get_repo()


### PR DESCRIPTION
If the current directory is not a repository, most git commands fail with a `StopIteration` error. This PR tries to fix that and issue a better error message 