### PR TITLE
fix crash when chdir to folder without access.

### DIFF
--- a/bin/cd.py
+++ b/bin/cd.py
@@ -20,7 +20,11 @@ def main(args):
     status = 0
     
     try:
-        os.chdir(ns.dir[0])
+       #chdir does not raise exception until listdir is called, so check for access here
+       if os.access(ns.dir[0],os.R_OK):
+          os.chdir(ns.dir[0])
+       else:
+          print('cd: {} access denied'.format(ns.dir[0]))
     except Exception as err:
         print("cd: {}: {!s}".format(type(err).__name__, err), file=sys.stderr)
         status = 1


### PR DESCRIPTION
when doing cd .. repeatedly, eventually stash crashes when it tries to create the prompt, in a no recoverable way.
the issue is because os.chdir does not raise an error, but os.listdir does.  this fix checks access before chdir.