### PR TITLE
Open file in new editor tab by default

### DIFF
--- a/bin/edit.py
+++ b/bin/edit.py
@@ -1,6 +1,6 @@
 """
 Used to create/open and edit files.
-[-t --temp] - Opens the file as a temporary file. Allowing editing and renaming. Previous script in the pythonista editor will be restored.
+[-t --temp] - Opens the file as a temporary file. Allowing editing and renaming. Previous script in the pythonista editor will be restored unless a new tab is edited.
 [-o --old_tab] - Open file in an old editor tab (default is new tab, which is possible since Pythonista 1.6, although not for make_new_file; see https://forum.omz-software.com/topic/2428/editor-observations)
 
 usage:
@@ -31,7 +31,7 @@ def open_temp(file='', new_tab=True):
             to_edit.close()
             
         print '***When you are finished editing the file, you must come back to console to confim changes***'
-        editor.open_file(temp.name)
+        editor.open_file(temp.name, new_tab)
         time.sleep(1.5)
         console.hide_output()
         input = raw_input('Save Changes? Y,N: ')
@@ -42,14 +42,16 @@ def open_temp(file='', new_tab=True):
             except:
                 save_as = file_to_edit
             
-            editor.open_file(cur_path)
+            if not new_tab:
+                editor.open_file(cur_path)
             with open(save_as,'w') as f:
                 with open(temp.name,'r') as tmp:
                     f.write(tmp.read())
                     
             print 'File Saved.'
         elif input=='N' or input=='n':
-            editor.open_file(cur_path)
+            if not new_tab:
+                editor.open_file(cur_path)
     
     except Exception, e:
         print e

--- a/bin/edit.py
+++ b/bin/edit.py
@@ -1,7 +1,7 @@
 """
 Used to create/open and edit files.
 [-t --temp] - Opens the file as a temporary file. Allowing editing and renaming. Previous script in the pythonista editor will be restored unless a new tab is edited.
-[-o --old_tab] - Open file in an old editor tab (default is new tab, which is possible since Pythonista 1.6, although not for make_new_file; see https://forum.omz-software.com/topic/2428/editor-observations)
+[-o --old_tab] - Open file in an old editor tab (default is new tab, which is possible from Pythonista 1.6, although not for make_new_file; see https://forum.omz-software.com/topic/2428/editor-observations)
 
 usage:
     edit [-t --temp] [-o --old_tab] [file]

--- a/bin/edit.py
+++ b/bin/edit.py
@@ -37,13 +37,16 @@ def open_temp(file='', new_tab=True):
         input = raw_input('Save Changes? Y,N: ')
     
         if input=='Y' or input=='y':
-            try:
-                save_as = raw_input('Save file as [Enter to confirm]: %s' % file_to_edit) or file_to_edit
-            except:
-                save_as = file_to_edit
-            
+            while True:
+                try:
+                    save_as = raw_input('Save file as [Enter to confirm]: %s' % file_to_edit) or file_to_edit
+                except:
+                    save_as = file_to_edit
+                if save_as:
+                    break
+
             if not new_tab:
-                editor.open_file(cur_path)
+                editor.open_file(cur_path) # restore previous script in editor
             with open(save_as,'w') as f:
                 with open(temp.name,'r') as tmp:
                     f.write(tmp.read())
@@ -51,7 +54,7 @@ def open_temp(file='', new_tab=True):
             print 'File Saved.'
         elif input=='N' or input=='n':
             if not new_tab:
-                editor.open_file(cur_path)
+                editor.open_file(cur_path) # restore previous script in editor
     
     except Exception, e:
         print e
@@ -68,14 +71,15 @@ def open_editor(file='', new_tab=True):
         
 if __name__=='__main__':
     ap = argparse.ArgumentParser()
-    ap.add_argument('-t','--temp',action='store_true',default=False,help='Open file to a temp file')
-    ap.add_argument('-o','--old_tab',action='store_true',default=False,help='Open file in an old editor tab (default is new tab)')
+    ap.add_argument('-t','--temp',action='store_true',default=False,help='open file to a temp file')
+    ap.add_argument('-o','--old_tab',action='store_true',default=False,help='open file in an old editor tab (default is new tab)')
     ap.add_argument('file', action='store',nargs='?',default=False,help='File to open')
     ns = ap.parse_args()
 
     # Calculate the relative path because absolute path crashes Pythonista
     # most likely due to access right for iOS root path.
-    filename = os.path.relpath(ns.file, '.')
+    if ns.file:
+        filename = os.path.relpath(ns.file, '.')
 
     if ns.temp and ns.file:
         open_temp(filename, new_tab=not ns.old_tab)

--- a/bin/edit.py
+++ b/bin/edit.py
@@ -1,9 +1,10 @@
 """
 Used to create/open and edit files.
 [-t --temp] - Opens the file as a temporary file. Allowing editing and renaming. Previous script in the pythonista editor will be restored.
+[-o --old_tab] - Open file in an old editor tab (default is new tab, which is possible since Pythonista 1.6, although not for make_new_file; see https://forum.omz-software.com/topic/2428/editor-observations)
 
 usage:
-    edit [-t --temp] [file]
+    edit [-t --temp] [-o --old_tab] [file]
     Follow prompt for instructions.
 """
 import os
@@ -61,12 +62,12 @@ def open_editor(file='', new_tab=True):
         editor.open_file(os.getcwd()+'/'+file, new_tab)
         console.hide_output()
     else:
-        editor.make_new_file(file if file else 'untitled.py')
+        editor.make_new_file(file if file else 'untitled.py') # new_tab not supported by make_new_file
         
 if __name__=='__main__':
     ap = argparse.ArgumentParser()
     ap.add_argument('-t','--temp',action='store_true',default=False,help='Open file to a temp file')
-    ap.add_argument('-o','--old',action='store_true',default=False,help='Open file in an old tab (default is new)')
+    ap.add_argument('-o','--old_tab',action='store_true',default=False,help='Open file in an old editor tab (default is new tab)')
     ap.add_argument('file', action='store',nargs='?',default=False,help='File to open')
     ns = ap.parse_args()
 
@@ -82,6 +83,3 @@ if __name__=='__main__':
 
     else:
         open_temp(new_tab=not ns.old_tab)
-
-
-

--- a/bin/edit.py
+++ b/bin/edit.py
@@ -14,7 +14,7 @@ import time
 import argparse
 
 
-def open_temp(file=''):
+def open_temp(file='', new_tab=True):
     try:
         file_to_edit = file
         temp = tempfile.NamedTemporaryFile(dir=os.path.expanduser('~/Documents') , suffix='.py')
@@ -56,16 +56,17 @@ def open_temp(file=''):
     finally:
         temp.close()
 
-def open_editor(file=''):
+def open_editor(file='', new_tab=True):
     if os.path.isfile(os.getcwd()+'/'+file):
-        editor.open_file(os.getcwd()+'/'+file)
+        editor.open_file(os.getcwd()+'/'+file, new_tab)
         console.hide_output()
     else:
         editor.make_new_file(file if file else 'untitled.py')
         
 if __name__=='__main__':
     ap = argparse.ArgumentParser()
-    ap.add_argument('-t','--temp',action='store_true',default=False,help='Open file to a temp file.')
+    ap.add_argument('-t','--temp',action='store_true',default=False,help='Open file to a temp file')
+    ap.add_argument('-o','--old',action='store_true',default=False,help='Open file in an old tab (default is new)')
     ap.add_argument('file', action='store',nargs='?',default=False,help='File to open')
     ns = ap.parse_args()
 
@@ -74,14 +75,13 @@ if __name__=='__main__':
     filename = os.path.relpath(ns.file, '.')
 
     if ns.temp and ns.file:
-        open_temp(filename)
+        open_temp(filename, new_tab=not ns.old_tab)
 
     elif ns.file:
-        open_editor(filename)
+        open_editor(filename, new_tab=not ns.old_tab)
 
     else:
-        open_temp()
-
+        open_temp(new_tab=not ns.old_tab)
 
 
 


### PR DESCRIPTION
With Pythonista 2.0 out, it's now possible to specify a file must be opened in a separate editor tab. This is desirable in the common use case, so I changed to make this the default behaviour, with an '--old_tab' option to reuse an existing editor tab (if any).
Also, while the argument specification made the path argument optional, this wasn't processed correctly. It should work correctly in all cases now (including some special casing if a path is specified neither at the start nor when saving a temporary file).