### PR TITLE
Fix ShIO.readlines()

### DIFF
--- a/system/shio.py
+++ b/system/shio.py
@@ -111,7 +111,7 @@ class ShIO(object):
         for line in ret.splitlines():
             self.stash.runtime.add_history(line)
 
-        return ret
+        return ret.splitlines(True)
 
     def read1(self):
         """


### PR DESCRIPTION
This fixes ShIO.readlines() which returned entire buffer string, instead of list of lines.