### PR TITLE
New command, bugfixes and improvements

### DIFF
--- a/bin/ftpserver.py
+++ b/bin/ftpserver.py
@@ -1,0 +1,95 @@
+"""Simple FTP Server"""
+import argparse
+import os
+import sys
+import threading
+import time
+import logging
+
+_stash = globals()["_stash"]
+
+try:
+	import pyftpdlib
+except ImportError:
+	print("Installing pyftpdlib...")
+	_stash("pip install pyftpdlib")
+	es = os.getenv("?")
+	if es != 0:
+		print(_stash.text_color("Failed to install pyftpdlib!", "red"))
+		sys.exit(1)
+
+from pyftpdlib.authorizers import DummyAuthorizer
+from pyftpdlib.servers import FTPServer
+from pyftpdlib.handlers import FTPHandler
+
+
+def run(ns):
+	"""starts the server."""
+	auth = DummyAuthorizer()
+	if ns.user is not None:
+		auth.add_user(ns.user, ns.pswd, ns.path, perm=ns.perm)
+	else:
+		auth.add_anonymous(ns.path, perm=ns.perm)
+	handler = FTPHandler
+	handler.authorizer = auth
+	handler.banner = "StaSh v{v} FTP-Server".format(v=_stash.__version__)
+	address = ("0.0.0.0", ns.port)
+	server = FTPServer(address, handler)
+	server.max_cons = 128
+	server.max_cons_per_ip = 128
+	# setup logging
+	logger = logging.getLogger("pyftpdlib")
+	logger.setLevel(logging.CRITICAL)
+	logger.propagate = False
+	# server needs to run in a thread to be killable
+	thr = threading.Thread(
+		name="FTP-Server Thread", target=server.serve_forever
+		)
+	thr.daemon = True
+	thr.start()
+	print("FTP-Server started on {h}:{p}".format(h=address[0], p=str(address[1])))
+	try:
+		while True:
+			time.sleep(0.2)
+	except KeyboardInterrupt:
+		print("Stopping Server...")
+		server.close_all()
+
+if __name__ == "__main__":
+	parser = argparse.ArgumentParser(description=__doc__)
+	parser.add_argument(
+		"-p", "--port", action="store", type=int,
+		default=21, dest="port", help="port to listen on"
+		)
+	parser.add_argument(
+		"-u", "--user", action="store", default=None, dest="user",
+		help="username (default: anonymous)"
+		)
+	parser.add_argument(
+		"--pswd", action="store", default=None, dest="pswd",
+		help="password"
+		)
+	parser.add_argument(
+		"--perm", action="store", default="elradfmwM", dest="perm",
+		help="permissions of the user"
+		)
+	parser.add_argument(
+		"--path", action="store", default=os.getcwd(), dest="path",
+		help="path to serve"
+		)
+	ns = parser.parse_args()
+	if (ns.user is not None) and (ns.pswd is None):
+		print(
+			_stash.text_color(
+				"Error: If user is given, pswd must also be given!", "red"
+				)
+			)
+		sys.exit(1)
+	if (ns.pswd is not None) and (ns.user is None):
+		print(
+			_stash.text_color(
+				"Error: If pswd is given, user must also be given!", "red"
+				)
+			)
+		sys.exit(1)
+	run(ns)

--- a/bin/mc.py
+++ b/bin/mc.py
@@ -368,10 +368,10 @@ This means, that this FSI lad not work on all FTP-servers."""
 			self.ftp.mkd(ap)
 		except Exception as e:
 			# test wether the dir exists
-			cwd = self.get_path()
+			self.get_path()
 			try:
 				self.cd(ap)
-			except Exception as e2:
+			except Exception:
 				raise e
 			else:
 				raise AlreadyExists("Already exists!")
@@ -473,7 +473,7 @@ class DropboxFSI(BaseFSI):
 			meta = self.client.metadata(path)
 			if not meta["is_dir"]:
 				raise IsDir()
-		except rest.ErrorResponse as e:
+		except rest.ErrorResponse:
 			raise OperationFailure("Not found!")
 		else:
 			self.path = path
@@ -483,7 +483,7 @@ class DropboxFSI(BaseFSI):
 			meta = self.client.metadata(self.path)
 		except rest.ErrorResponse as e:
 			raise OperationFailure(e.error_msg)
-		return [e["path"].split("/")[-1] for e in meta["contents"]]
+		return [el["path"].split("/")[-1] for el in meta["contents"]]
 
 	def mkdir(self, name):
 		if name.startswith("/"):
@@ -504,7 +504,7 @@ class DropboxFSI(BaseFSI):
 			path = os.path.join(self.path, name)
 		try:
 			self.client.file_delete(path)
-		except rest.ErrorResponse as e:
+		except rest.ErrorResponse:
 			raise OperationFailure("Can not delete target!")
 
 	def isdir(self, name):
@@ -515,7 +515,7 @@ class DropboxFSI(BaseFSI):
 		try:
 			meta = self.client.metadata(path)
 			return meta["is_dir"]
-		except rest.ErrorResponse as e:
+		except rest.ErrorResponse:
 			return False
 
 	def isfile(self, name):
@@ -526,7 +526,7 @@ class DropboxFSI(BaseFSI):
 		try:
 			meta = self.client.metadata(path)
 			return not meta["is_dir"]
-		except rest.ErrorResponse as e:
+		except rest.ErrorResponse:
 			return False
 
 	def open(self, name, mode="rb"):
@@ -611,11 +611,11 @@ def dropbox_setup(stdin, stdout):
 		"I dont have a appkey+secret", abort
 		)
 	choice = menu(header, choices, stdin, stdout)
-	if choice == 0:
+	if choice == 2:
 		raise OperationFailure("Setup aborted.")
-	elif choice == 1:
+	elif choice == 0:
 		pass
-	elif choice == 2:
+	elif choice == 1:
 		stdout.write("Please read this. After reading, press enter to continue.\n")
 		text1 = "To allow mc access to your dropbox, "
 		text2 = "you will have to perform the following steps:\n"
@@ -653,7 +653,7 @@ def dropbox_setup(stdin, stdout):
 		appsecret = clipboard.get()
 		stdout.write("Using clipboard (length={l}).\n".format(l=len(appsecret)))
 	while True:
-		stdout.write("Enter access type:\n")
+		stdout.write("Enter access type (dropbox/app_folder):\n")
 		accesstype = stdin.readline().strip()
 		if accesstype not in ("dropbox", "app_folder"):
 			text = Text(
@@ -744,7 +744,7 @@ def menu(header, choices, stdin=None, stdout=None):
 		try:
 			answer = int(answer)
 			return answer
-		except (KeyError, ValueError, IndexError) as e:
+		except (KeyError, ValueError, IndexError):
 			stdout.write("\n"*20)
 
 
@@ -1222,7 +1222,7 @@ MODE should be either 'r' or 'w'. 'r' only downloads the files,
 			return
 		mode = args[1]
 		remotepath = args[0]
-		orgpath = remotepath
+		# orgpath = remotepath
 		if not (rfsi.isfile(remotepath) or remotepath == "*"):
 			self.stdout.write(
 				Text("Error: to download a whole directory use '*'.\n", "red")
@@ -1415,6 +1415,7 @@ I cant copy/move a directory on the same interface:
 		You can fix this by creating a second interface with the same
 			dir and copy/move between them instead.
 """
+		sys.stdout.write(av + "\n")
 	help_helpme = help_troubleshooting
 
 	def help_fsis(self, *args):

--- a/bin/python.py
+++ b/bin/python.py
@@ -18,6 +18,8 @@ import argparse
 import code
 import __builtin__
 
+_stash = globals()["_stash"]
+
 args = sys.argv[1:]
 
 passing_h = False
@@ -70,6 +72,8 @@ else:
             '__name__': '__main__',
             '__doc__': None,
             '__package__': None,
+            '__debug__': True,
             '__builtins__': __builtin__,  # yes, __builtins__
+            '_stash': _stash,
         }
         code.interact(local=locals)

--- a/man/manpages.txt
+++ b/man/manpages.txt
@@ -1,0 +1,12 @@
+The 'man' command
+------------------
+- If no arguments are given, man wil list all commands in '$STASH_ROOT/bin/'.
+- If one argument is given and a command has this name, man will print the docstring of this command.
+- If one argument is given and no command has this name, man will search for files and folders with this name in '$STASH_ROOT/man/'.
+man will ignore file-extensions and numbers in brackets when searching for files.
+  - If a file with this name has been found, man will check the file extenson.
+    - If the extension is '.txt' or unknown, man will print the content of the file.
+    - If the extension is '.html', man will open the file in quicklook.
+    - If the extension is '.url':
+      - If the content of the file starts with 'stash://', man will restart it's search in the path specified in the content of the file, replacing 'stash://' with '$STASH_ROOT/'.
+  - If a dir with this name has been found, man will check wether argument passed contains brackets with a number between. If no number if given, man will use 1. man will then show the page starting with page_N, where n is the number.


### PR DESCRIPTION
Yet another bunch of bugfixes for the `mc`-command, but also some improvements to the python-command.

**New Command and Files**
- `ftpserver` uses pyftpdlib to start a ftpserver. I frequently use omz`s ftpserver and tought it may be usefull to add to StaSh.
- added a helppage for the manpages. I tought it may be useful to document the behavior of the new `man`-command (in case others want to write manpages; i dont think my english is sufficent to write anything wich is not to hard to read)

**Improvements**
- The `python` command will now pass `_stash` and `__debug__` to the interactive interpreter.
- cleaned up the code of the `mc`-command by removing all unnecessary assignments in `except-clauses`.

**Bugfixes**
- Fixed a bug in `mc` where menu-entries were swapped. I accidently added this when cleaning up the menu-entries in `mc`  in an earlier commit.
- Fixed a bug in `mc` where no help was shown for a topic.

**Short info**
- I have updated the `getstash.py`-file in my fork, so testing this changes with `selfupdate -f bennr01:dev` should work now. I recently noticed that `seldupdate -f user:branch` wont work if the fork still contains the old `getstash.py`.

Also, a question: What do you think about the idea of adding a command for enabling and disabling monkeypatches for modules and functions not working in Pythonista? For example, patching `subprocessing` and `os.popen` to call the shell-commands in StaSh. The functions and modules i thought about patching dont work in Pythonista, so this could make more "normal" python-scripts compatible with Pythonista by using StaSh. Also, because they dont work by default, any weird behavior caused by monkeypatching should be acceptable because the scripts would still work more than by not doing any monkeypatching. The monkey-patching would be done by a command, which would have to be run by the user everytime he wants to enable them (they would be disabled by default and resetted whn Pythonista restarts).