### PR TITLE
Fix ShIO.readline() handling of Ctrl-D

### DIFF
--- a/system/shio.py
+++ b/system/shio.py
@@ -81,10 +81,13 @@ class ShIO(object):
         while True:
             try:
                 ret.append(self._buffer.pop())
-                if ret[-1] == '\n':
+                if ret[-1] in ['\n', '\0']:
                     break
             except IndexError:
                 time.sleep(self.holdback)
+
+        if ret[-1] == '\0':
+            del ret[-1]
 
         line = ''.join(ret)
         # localized history for running scripts


### PR DESCRIPTION
This fixes that `'\0'` character was wrongly sent to running script, when `CD` key in virtual keyboard was pressed.

This fixes e.g. `CD` terminates `python` command with following exception:
```
stash: <type 'exceptions.TypeError'>: compile() expected string without null bytes
```