### PR TITLE
Made StaSh more extensible; pip now handles command line scripts; fixes

### DIFF
--- a/bin/man.py
+++ b/bin/man.py
@@ -114,9 +114,12 @@ def find_command(cmd):
 
 		
 def get_docstring(filename):
-	with open(filename) as f:
-		tree = ast.parse(f.read(), os.path.basename(filename))
-	return ast.get_docstring(tree)
+	try:
+		with open(filename) as f:
+			tree = ast.parse(f.read(), os.path.basename(filename))
+		return ast.get_docstring(tree)
+	except:
+		return "UNKNOWN"
 
 		
 def get_summary(filename):

--- a/bin/man.py
+++ b/bin/man.py
@@ -19,6 +19,7 @@ _stash = globals()["_stash"]
 TYPE_CMD = "command"
 TYPE_PAGE = "page"
 TYPE_NOTFOUND = "not found"
+TYPE_LISTTOPICS = "list topics"
 
 MAIN_BINPATH = os.path.join(os.environ["STASH_ROOT"], "bin")
 MAIN_PAGEPATH = os.path.join(os.environ["STASH_ROOT"], "man")
@@ -47,6 +48,8 @@ def all_commands():
 		
 def get_type(search):
 	"""returns (type, path) for a given topic/command."""
+	if search == "topics":
+		return (TYPE_LISTTOPICS, None)
 	cmdpath = find_command(search)
 	if cmdpath is not None:
 		return (TYPE_CMD, cmdpath)
@@ -86,6 +89,8 @@ def get_type(search):
 			pname = "page_" + str(pn)
 			for pp in PAGEPATHS:
 				dirpath = os.path.join(pp, to_search)
+				if not os.path.exists(dirpath):
+					continue
 				for fn in os.listdir(dirpath):
 					if fn.startswith(pname):
 						fp = os.path.join(dirpath, fn)
@@ -167,6 +172,21 @@ def show_text(text):
 	print("\n")
 
 
+def show_topics():
+	"""prints all available miscellaneous help topics."""
+	print(_stash.text_color("Miscellaneous Topics:", "yellow"))
+	for pp in PAGEPATHS:
+		if not os.path.isdir(pp):
+			continue
+		content = os.listdir(pp)
+		for pn in content:
+			if "." in pn:
+				name = pn[:pn.index(".")]
+			else:
+				name = pn
+			print(name)
+
+
 def main(args):
 	ap = argparse.ArgumentParser(description=__doc__)
 	ap.add_argument("topic", nargs="?", help="the command/topic to get help for")
@@ -181,16 +201,19 @@ def main(args):
 			print(
 				_stash.text_bold('{:>11}: '.format(cmd)) + get_summary(find_command(cmd))
 				)
+		print("Type 'man topics' to see miscellaneous help topics")
 		sys.exit(0)
 	else:
 		ft, path = get_type(ns.topic)
-		
 		if ft == TYPE_NOTFOUND:
 			print(
 				_stash.text_color("man: no help for '{}'".format(ns.topic), "red")
 			)
 			sys.exit(1)
-		if ft == TYPE_CMD:
+		if ft == TYPE_LISTTOPICS:
+			show_topics()
+			sys.exit(0)
+		elif ft == TYPE_CMD:
 			try:
 				docstring = get_docstring(path)
 			except Exception as err:

--- a/launch_stash.py
+++ b/launch_stash.py
@@ -47,6 +47,9 @@ ap.add_argument('-c', '--command',
                 default=None,
                 dest='command',
                 help='command to run')
+ap.add_argument('args',  # the editor shortcuts may pass additional arguments
+                nargs='*',
+                help='additional arguments (ignored)')
 ns = ap.parse_args()
 
 log_setting = {

--- a/launch_stash.py
+++ b/launch_stash.py
@@ -43,9 +43,9 @@ ap.add_argument('--log-file',
 ap.add_argument('--debug-switch',
                 default='',
                 help='a comma separate list to turn on debug switch for components')
-ap.add_argument('command',
+ap.add_argument('-c', '--command',
                 default=None,
-                nargs='?',
+                dest='command',
                 help='command to run')
 ns = ap.parse_args()
 

--- a/lib/mlpatches/patches.py
+++ b/lib/mlpatches/patches.py
@@ -1,4 +1,7 @@
 """This module contains a dictionary containing all patches and their name."""
+from stash.system.shcommon import _STASH_EXTENSION_PATCH_PATH
+
+from stashutils.core import load_from_dir
 
 from mlpatches import base, os_patches, modulepatches, tl_patches
 from mlpatches import mount_patches
@@ -22,7 +25,26 @@ INSTABLE_PATCHES = {  # name -> Patch()
 	"MOUNT": mount_patches.MOUNT_PATCHES,
 }
 
-# create a empty dict and update it
+# update with extensions
+extensions = load_from_dir(
+	dirpath=_STASH_EXTENSION_PATCH_PATH, varname="STABLE_PATCHES",
+	)
+for ext in extensions:
+	if not isinstance(ext, dict):
+		continue
+	else:
+		STABLE_PATCHES.update(ext)
+
+extensions = load_from_dir(
+	dirpath=_STASH_EXTENSION_PATCH_PATH, varname="INSTABLE_PATCHES",
+	)
+for ext in extensions:
+	if not isinstance(ext, dict):
+		continue
+	else:
+		INSTABLE_PATCHES.update(ext)
+
+# create an empty dict and update it
 
 PATCHES = {}
 

--- a/lib/stashutils/core.py
+++ b/lib/stashutils/core.py
@@ -1,5 +1,8 @@
 """core utilities for StaSh-scripts"""
 import threading
+import imp
+import os
+
 from stash.system import shthreads
 
 
@@ -18,3 +21,23 @@ def get_stash():
 				ct = ct.parent
 			return ct.parent.stash
 	return None
+
+
+def load_from_dir(dirpath, varname):
+	"""
+	returns a list of all variables named 'varname' in .py files in a directofy 'dirname'.
+	"""
+	if not os.path.isdir(dirpath):
+		return []
+	ret = []
+	for fn in os.listdir(dirpath):
+		fp = os.path.join(dirpath, fn)
+		if not os.path.isfile(fp):
+			continue
+		with open(fp, "r") as fin:
+			mod = imp.load_source(fn[:fn.index(".")], fp, fin)
+		if not hasattr(mod, varname):
+			continue
+		else:
+			ret.append(getattr(mod, varname))
+	return ret

--- a/lib/stashutils/extensions.py
+++ b/lib/stashutils/extensions.py
@@ -1,0 +1,65 @@
+"""This module defines functions to interact with stash extensions."""
+import os
+import shutil
+
+from stash.system.shcommon import _STASH_EXTENSION_BIN_PATH as EBP
+from stash.system.shcommon import _STASH_EXTENSION_MAN_PATH as EMP
+from stash.system.shcommon import _STASH_EXTENSION_FSI_PATH as EFP
+from stash.system.shcommon import _STASH_EXTENSION_PATCH_PATH as EPP
+
+from stashutils.core import load_from_dir
+
+
+# alias load_from_dir (so you can access it trough this namespace)
+load_from_dir = load_from_dir
+
+
+def create_file(dest, content):
+	"""
+	creates a file at dest with content.
+	If content is a string or unicode, use it as the content.
+	Otherwise, use content.read() as the content.
+	"""
+	if not isinstance(content, (str, unicode)):
+		content = content.read()
+	with open(dest, "wb") as f:
+		f.write(content)
+
+
+def create_page(name, content):
+	"""
+	creates a manpage with name filled with content.
+	If content is a list or tuple, instead create a dir and fill it with pages
+	created from the elements of this list.
+	The list should consist of tuples of (ending, content)
+	"""
+	path = os.path.join(EMP, name)
+	if isinstance(content, (list, tuple)):
+		# create a bunch of pages
+		if os.path.exists(path):
+			shutil.rmtree(path)
+		os.mkdir(path)
+		for n, element in enumerate(content, 1):
+			ending, elementcontent = element
+			pagename = "{b}/page_{n}.{e}".format(n=n, e=ending, b=path)
+			create_page(pagename, elementcontent)
+	else:
+		create_file(path, content)
+
+
+def create_command(name, content):
+	"""creates a script named name filled with content"""
+	path = os.path.join(EBP, name)
+	create_file(path, content)
+
+
+def create_fsi_file(name, content):
+	"""creates a fsi extension named name filled with content"""
+	path = os.path.join(EFP, name)
+	create_file(path, content)
+
+
+def create_patch_file(name, content):
+	"""creates a patch extension named name filled with content"""
+	path = os.path.join(EPP, name)
+	create_file(path, content)

--- a/lib/stashutils/extensions.py
+++ b/lib/stashutils/extensions.py
@@ -24,6 +24,7 @@ def create_file(dest, content):
 		content = content.read()
 	with open(dest, "wb") as f:
 		f.write(content)
+	return dest
 
 
 def create_page(name, content):
@@ -43,23 +44,24 @@ def create_page(name, content):
 			ending, elementcontent = element
 			pagename = "{b}/page_{n}.{e}".format(n=n, e=ending, b=path)
 			create_page(pagename, elementcontent)
+		return path
 	else:
-		create_file(path, content)
+		return create_file(path, content)
 
 
 def create_command(name, content):
 	"""creates a script named name filled with content"""
 	path = os.path.join(EBP, name)
-	create_file(path, content)
+	return create_file(path, content)
 
 
 def create_fsi_file(name, content):
 	"""creates a fsi extension named name filled with content"""
 	path = os.path.join(EFP, name)
-	create_file(path, content)
+	return create_file(path, content)
 
 
 def create_patch_file(name, content):
 	"""creates a patch extension named name filled with content"""
 	path = os.path.join(EPP, name)
-	create_file(path, content)
+	return create_file(path, content)

--- a/lib/stashutils/fsi/interfaces.py
+++ b/lib/stashutils/fsi/interfaces.py
@@ -1,10 +1,12 @@
 """
 This module contains a dictionary mapping the identifiers to the fsi-classes
 """
+from stash.system.shcommon import _STASH_EXTENSION_FSI_PATH
 from stashutils.fsi.local import LocalFSI
 from stashutils.fsi.FTP import FTPFSI
 from stashutils.fsi.DropBox import DropboxFSI
 from stashutils.fsi.zip import ZipfileFSI
+from stashutils.core import load_from_dir
 
 # map type -> FSI_class
 FILESYSTEM_TYPES = {
@@ -20,6 +22,16 @@ FILESYSTEM_TYPES = {
 	"ZIP": ZipfileFSI,
 	"zipfile": ZipfileFSI,
 }
+
+# update with extensions
+extensions = load_from_dir(
+	dirpath=_STASH_EXTENSION_FSI_PATH, varname="FSIS",
+	)
+for ext in extensions:
+	if not isinstance(ext, dict):
+		continue
+	else:
+		FILESYSTEM_TYPES.update(ext)
 
 # alias used by mc
 INTERFACES = FILESYSTEM_TYPES

--- a/man/manpages.txt
+++ b/man/manpages.txt
@@ -1,12 +1,13 @@
 The 'man' command
 ------------------
-- If no arguments are given, man wil list all commands in '$STASH_ROOT/bin/'.
+- If no arguments are given, man wil list all commands in '$BIN_PATH'.
+- If the argument "topics" is given, list all non-command topics.
 - If one argument is given and a command has this name, man will print the docstring of this command.
-- If one argument is given and no command has this name, man will search for files and folders with this name in '$STASH_ROOT/man/'.
+- If one argument is given and no command has this name, man will search for files and folders with this name in '$STASH_ROOT/man/' and '$HOME2/stash_extensions/man/'.
 man will ignore file-extensions and numbers in brackets when searching for files.
   - If a file with this name has been found, man will check the file extenson.
     - If the extension is '.txt' or unknown, man will print the content of the file.
     - If the extension is '.html', man will open the file in quicklook.
     - If the extension is '.url':
       - If the content of the file starts with 'stash://', man will restart it's search in the path specified in the content of the file, replacing 'stash://' with '$STASH_ROOT/'.
-  - If a dir with this name has been found, man will check wether argument passed contains brackets with a number between. If no number if given, man will use 1. man will then show the page starting with page_N, where n is the number.
+  - If a dir with this name has been found, man will check whether the argument passed contains brackets with a number between. If no number is given, man will assume it to be 1. man will then show the page starting with page_N, where n is the number.

--- a/man/monkeypatching/page_4.txt
+++ b/man/monkeypatching/page_4.txt
@@ -34,8 +34,8 @@ OS_POPEN: The patches for "os.popen*".
 OS_PROCESSING: patches to emulate process-like behavior
 
 
-Available Patches:
-------------------
+Some of the Available Patches:
+------------------------------
 
 os_popen: make "os.popen" use StaSh.
 os_popen2: make "os.popen2" use StaSh.

--- a/man/monkeypatching/page_5.txt
+++ b/man/monkeypatching/page_5.txt
@@ -1,7 +1,7 @@
 monkeypatching(5) --- CREATING NEW PATCHES
 ==========================================
 
-All Patches are contained in modules in "$STASH_ROOT/lib/mlpatches".
+All builtin Patches are contained in modules in "$STASH_ROOT/lib/mlpatches".
 
 The following Patchtypes are available:
    BasePatch():
@@ -43,9 +43,15 @@ class MyPatch(base.FunctionPatch):
 MY_PATCH = MyPatch()
 '''
 
-ModulePatches should be defined in the "modulepatches"-submodule of mlpatches.
+Builtin ModulePatches should be defined in the "modulepatches"-submodule of mlpatches.
 They need to be registered in "modulepatches.MODULE_PATCHES" dictionary.
 This should be done in a hardcoded way.
 
-All other Patches should be defined and instanciated in their own module.
+All other builtin Patches should be defined and instanciated in their own module.
 They should then be imported in the "patches" submodule and registered in the "patches.(IN)STABLE_PATCHES" dictionary.
+
+You can also add your own patches in "$HOME2/stash_extension/patches/" if you dont want to modify StaSh.
+In this case you can define a dictionary named "STABLE_PATCHES" and/or a dictionary named "INSTABLE_PATCHES".
+They should map a name to a patch instance.
+Extensions are only loaded the first time the "monkeylord"-command is executed.
+If you want to reload the extensions, force-quit Pythonista  and restart StaSh.

--- a/man/mounting/page_3.txt
+++ b/man/mounting/page_3.txt
@@ -23,6 +23,8 @@ The 'mount'-system uses Filesystem-Interfaces (short: FSIs) to handle the filesy
 Most of the FSIs were first implemented in the 'mc'-command's sourcecode and have been extracted.
 Because of this, the FSI-API was initially not designed for the 'mount'-system, but has been extended for the 'mount'-command.
 Also, the FSI-API is designed to uses at least methods as possible, which may lead to performance-issues, but is required in order to easily support many different filesystem-types.
-All FSIs are defined in '$STASH_ROOT/lib/stashutils/fsi/' and are registered in '$STASH_ROOT/lib/stashutils/fsi/interfaces.py'.
+All builtin FSIs are defined in '$STASH_ROOT/lib/stashutils/fsi/' and are registered in '$STASH_ROOT/lib/stashutils/fsi/interfaces.py'.
+You can easily extend the FSIs by adding a file in '$HOME2/stash_extensions/fsi/' which defines a dictionary named 'FSIS'.
+The Keys of this dictionary should be the names of the FSIs, the values the FSI.
 
 If you want to access another filesystem, but dont want to use monkeypatches, use the 'mc'-command. They use the same FSIs, but 'mc' defines its own commands while mount allows the use of StaSh's commands.

--- a/man/mounting/page_6.txt
+++ b/man/mounting/page_6.txt
@@ -4,12 +4,18 @@ MOUNTING(6) --- DEVELOPER INFORMATIONS
 This page explains how you can help expanding the mount-system.
 IMPORTANT: many changes to the mount-system requires a restart of pythonista.
 
-If you want to add support for another filesystem/service:
+If you want to add builtin support for another filesystem/service:
 	1. Create a '.py' file in '$STASH_ROOT/lib/stashutils/fsi/'.
-	2. In this file, define a class which implements the API defined in '$STASH_ROOT/lib/stashutils/fsi/base.py/BaseFSI'. You mad also want to take a look at the utility functions zhis module provide. Your class should be a subclass of the BaseFSI class.
-	3. modify '$STASH_ROOT/lib/stashutils/fsi/interfaces.py' to implort the class, then register the class in the 'FILESYSTEM_TYPES'-dictionary.
+	2. In this file, define a class which implements the API defined in '$STASH_ROOT/lib/stashutils/fsi/base.py/BaseFSI'. You mad also want to take a look at the utility functions this module provide. Your class should be a subclass of the BaseFSI class.
+	3. modify '$STASH_ROOT/lib/stashutils/fsi/interfaces.py' to import the class, then register the class in the 'FILESYSTEM_TYPES'-dictionary.
 	4. Test it and fix it if required.
 	5. Done. You may want to create a pull-request.
+
+If you want to add a FSI without modifying the '$STASH_ROOT' directory:
+    1. Create a '.py' file in '$HOME2/stash_extensions/fsi/'.
+    2. Do step 2 of 'adding builtin support' (see above).
+    3. In the file, define a dictionary mapping the FSI-names to the FSI-classes.
+    4. Done.
 
 If you want to define more patches:
 	1. read the 'monkeypatching' documentation using 'man'.
@@ -19,6 +25,6 @@ If you want to define more patches:
 
 TODO:
 	- add FSI for samba (windows filesystem access). See 'pysamba'.
-	- add FSI for '.iso'-files. see the github repo of 'pyiso'.
+	- add FSI for '.iso'-files. See the github repo of 'pyiso'.
 
 Thanks for your interest.

--- a/stash.py
+++ b/stash.py
@@ -77,7 +77,10 @@ VK_SYMBOLS=~/.-*|>$'=!&_"\?`
 # this directories
 for p in _EXTERNAL_DIRS:
 	if not os.path.exists(p):
-		os.mkdir(p)
+		try:
+			os.mkdir(p)
+		except:
+			pass
 
 
 class StaSh(object):

--- a/stash.py
+++ b/stash.py
@@ -20,6 +20,7 @@ import logging.handlers
 from .system.shcommon import IN_PYTHONISTA, ON_IPAD
 from .system.shcommon import _STASH_ROOT, _STASH_CONFIG_FILES, _SYS_STDOUT
 from .system.shcommon import Graphics as graphics, Control as ctrl, Escape as esc
+from .system.shcommon import _EXTERNAL_DIRS
 from .system.shuseractionproxy import ShUserActionProxy
 from .system.shiowrapper import enable as enable_io_wrapper, disable as disable_io_wrapper
 from .system.shparsers import ShParser, ShExpander, ShCompleter
@@ -69,6 +70,14 @@ BUFFER_MAX=150
 AUTO_COMPLETION_MAX=50
 VK_SYMBOLS=~/.-*|>$'=!&_"\?`
 """.format(text_size=14 if ON_IPAD else 12)
+
+
+# create directories outside STASH_ROOT
+# we should do this each time StaSh because some commands may require
+# this directories
+for p in _EXTERNAL_DIRS:
+	if not os.path.exists(p):
+		os.mkdir(p)
 
 
 class StaSh(object):

--- a/system/shcommon.py
+++ b/system/shcommon.py
@@ -59,11 +59,14 @@ _STASH_EXTENSION_PATH = os.path.abspath(
 _STASH_EXTENSION_BIN_PATH = os.path.join(_STASH_EXTENSION_PATH, "bin")
 # directory for stash man extensions
 _STASH_EXTENSION_MAN_PATH = os.path.join(_STASH_EXTENSION_PATH, "man")
+# directory for stash FSI extensions
+_STASH_EXTENSION_FSI_PATH = os.path.join(_STASH_EXTENSION_PATH, "fsi")
 # list of directories outside of _STASH_ROOT, used for simple mkdir
 _EXTERNAL_DIRS = [
 	_STASH_EXTENSION_PATH,
 	_STASH_EXTENSION_BIN_PATH,
 	_STASH_EXTENSION_MAN_PATH,
+	_STASH_EXTENSION_FSI_PATH,
 	]
 
 # Save the true IOs

--- a/system/shcommon.py
+++ b/system/shcommon.py
@@ -51,6 +51,20 @@ _STASH_ROOT = os.path.realpath(os.path.abspath(
     os.path.dirname(os.path.dirname(__file__))))
 _STASH_CONFIG_FILES = ('.stash_config', 'stash.cfg')
 _STASH_HISTORY_FILE = '.stash_history'
+# directory for stash extensions
+_STASH_EXTENSION_PATH = os.path.abspath(
+	os.path.join(os.getenv("HOME"), "Documents", "stash_extensions"),
+	)
+# directory for stash bin extensions
+_STASH_EXTENSION_BIN_PATH = os.path.join(_STASH_EXTENSION_PATH, "bin")
+# directory for stash man extensions
+_STASH_EXTENSION_MAN_PATH = os.path.join(_STASH_EXTENSION_PATH, "man")
+# list of directories outside of _STASH_ROOT, used for simple mkdir
+_EXTERNAL_DIRS = [
+	_STASH_EXTENSION_PATH,
+	_STASH_EXTENSION_BIN_PATH,
+	_STASH_EXTENSION_MAN_PATH,
+	]
 
 # Save the true IOs
 if IN_PYTHONISTA:

--- a/system/shcommon.py
+++ b/system/shcommon.py
@@ -61,12 +61,15 @@ _STASH_EXTENSION_BIN_PATH = os.path.join(_STASH_EXTENSION_PATH, "bin")
 _STASH_EXTENSION_MAN_PATH = os.path.join(_STASH_EXTENSION_PATH, "man")
 # directory for stash FSI extensions
 _STASH_EXTENSION_FSI_PATH = os.path.join(_STASH_EXTENSION_PATH, "fsi")
+# directory for stash patch extensions
+_STASH_EXTENSION_PATCH_PATH = os.path.join(_STASH_EXTENSION_PATH, "patches")
 # list of directories outside of _STASH_ROOT, used for simple mkdir
 _EXTERNAL_DIRS = [
 	_STASH_EXTENSION_PATH,
 	_STASH_EXTENSION_BIN_PATH,
 	_STASH_EXTENSION_MAN_PATH,
 	_STASH_EXTENSION_FSI_PATH,
+	_STASH_EXTENSION_PATCH_PATH,
 	]
 
 # Save the true IOs

--- a/system/shruntime.py
+++ b/system/shruntime.py
@@ -20,13 +20,13 @@ from .shcommon import ShBadSubstitution, ShInternalError, ShIsDirectory, \
     ShFileNotFound, ShEventNotFound, ShNotExecutable
 # noinspection PyProtectedMember
 from .shcommon import _STASH_ROOT, _STASH_HISTORY_FILE, _SYS_STDOUT, _SYS_STDERR
-from .shcommon import is_binary_file
+from .shcommon import is_binary_file, _STASH_EXTENSION_BIN_PATH
 from .shparsers import ShPipeSequence
 from .shthreads import ShBaseThread, ShTracedThread, ShCtypesThread, ShState, ShWorkerRegistry
 
 
 # Default .stashrc file
-_DEFAULT_RC = r"""BIN_PATH=~/Documents/bin:$BIN_PATH
+_DEFAULT_RC = r"""BIN_PATH=~/Documents/bin:{bin_ext}:$BIN_PATH
 SELFUPDATE_BRANCH=master
 PYTHONPATH=$STASH_ROOT/lib:$PYTHONPATH
 alias env='printenv'
@@ -37,7 +37,9 @@ alias ll='ls -la'
 alias copy='pbcopy'
 alias paste='pbpaste'
 alias unmount='umount'
-"""
+""".format(
+	bin_ext=_STASH_EXTENSION_BIN_PATH,
+	)
 
 
 class ShRuntime(object):


### PR DESCRIPTION
This pull request makes StaSh more extensible, extends `pip` and contains some fixes.

When StaSh launches, it will now create some folders for extensions:
- `$HOME2/stash_extensions/`: parent directory for extensions (to keep them sorted).
- `$HOME2/stash_extensions/bin/`: This directory is now in `$BIN_PATH`. It may/can/should be used by scripts automatically creating StaSh commands. While it would also be possible to create the commands in `$STASH_ROOT/bin` or `$HOME2/bin`, both have some limitations. `$STASH_ROOT/bin` may be overwritten during an update (or worse, some command may overwrite an important StaSh command). `$HOME2/bin` may contain scripts by the user or other data, which means that no script can be sure it is allowed to overwrite the contents of this directory. Also, due to #160, `man` wont print docstrings for commands in this directory.
- `$HOME2/stash_extensions/man/`: the `man` command will also look here for non-command topics.
- `$HOME2/stash_extensions/fsi/`: the `mount` and `mc` commands will try to load FSIs (=FileSystemInterfaces, the abstract class used by the mounting system to interact with filesystems) from modules in this directory. It will import these files and check for a dictionary named `FSIS` (mapping the names to the FSI-classes) and then register them.
- `$HOME2/stash_extensions/patches`: the `monkeylord` command will look for files in this directory, import them and look for variables named `STABLE_PATCHES` and `INSTABLE_PATCHES` (both mapping the name of the patches to patch instances) and then register them.

However, most of these checks are only done whenever they are first required and thus may require you to restart Pythonista before using the extensions.
The directory in which the extensions are stored (default: `$HOME2/stash_extensions/`) can be changed by changing a variable in `shcommon.py`.
There is also an API to create these extensions available as `stashutils.extensions` (stored in `$STASH_ROOT/lib/`). The API automatically creates the file in the correct location (which makes changing the installation directory easier because you would only need to change one line).
The corresponding documentations (`mounting`, `monkeypatching`...) have been updated.

I have changed the `command` argument added in #216 into a `--command COMMAND` argument and make `launch_stash.py` ignore additional arguments to fix some problems in the beta. This should fix #225, however i am unable to test this due to not having access to the beta.

The `man` command can now list all non-command topics by using `man topics` and will ignore invalid python files.

And last, but not least (and probably the most important of this pull request): The `pip` command now handles command line scripts defined in the `setup()` call.
It handles both the `scripts` keyword argument and the `entry_points` keyword argument, however it will only create the docstrings for `entry_points={"console_scripts":...}` commands (because the docstring of files using `scripts` may define their own). Also, only the `console_scripts` entry point will be handled and other entry points will print a warning.
The commands are created using the extension API defined in `$STASH_ROOT/lib/stashutils/extensions/` and thus create the commands in `$HOME2/stash_extensions/bin/`.
For example, `pip install django` will install the `django-admin` command (this may require a restart of Pythonista, but this is varying between different packages). `pip install kvndb` creates the `kvndb` command and the `twistd`(due to having `twisted` as a requirement)`.
This greatly improves the extensibility of StaSh due to making StaSh capable of using the ten-thousands of command line interfaces available on pypi.

By the way, here are a few questions (you dont need to answer them if you are busy):
1. Should we/you close #167 (The `mount` idea issue)? The `mount` system is now mostly implemented.
2. About python2/3 cross-version running: Is the code for executing a statement in python3 from pyhon2 available somewhere?

Thanks