### PR TITLE
Bugfixes

### DIFF
--- a/bin/crypt.py
+++ b/bin/crypt.py
@@ -13,48 +13,60 @@ optional arguments:
   -k KEY, --key KEY  Encrypt/Decrypt Key.
   -d, --decrypt      Flag to decrypt.
 '''
-import sys
 import os
+import argparse
+import base64
+
 try:
-    from simplecrypto.key import AesKey
+	import pyaes
 except:
-    print 'Installing Required packages.'
-    _stash('pip install simplecrypto')
-    sys.exit(0)
+	print 'Installing Required packages.'
+	_stash('pip install pyaes')
+	import pyaes
 
+	
 class Crypt(object):
-    def __init__(self,in_filename,out_filename=None):
-        self.in_filename = in_filename
-        self.out_filename = out_filename
-        
-    def aes_encrypt(self,key=None, chunksize=64*1024):
-        self.out_filename = self.out_filename or self.in_filename+'.enc'
-        aes = AesKey(key)
-        with open(self.in_filename, 'rb') as infile:
-            with open(self.out_filename, 'wb') as outfile:
-                outfile.write(aes.encrypt_raw(infile.read()))
-            
-        
-    def aes_decrypt(self,key, chunksize=64*1024):
-        self.out_filename = self.out_filename or os.path.splitext(self.in_filename)[0]
-        aes = AesKey(key)
-
-        with open(self.in_filename, 'rb') as infile:
-            with open(self.out_filename, 'wb') as outfile:
-                outfile.write(aes.decrypt_raw(infile.read()))
-
-            
-if __name__=='__main__':
-    ap = argparse.ArgumentParser()
-    ap.add_argument('-k','--key',action='store',default='',help='Encrypt/Decrypt Key.')
-    ap.add_argument('-d','--decrypt',action='store_true',default=False,help='Flag to decrypt.')
-    #ap.add_argument('-t','--type',action='store',choices={'aes','rsa'},default='aes')
-    ap.add_argument('infile',action='store',help='File to encrypt/decrypt.')
-    ap.add_argument('outfile',action='store',nargs='?',help='Output file.')
-    args = ap.parse_args()
-    crypt = Crypt(args.infile,args.outfile)
-    if args.decrypt:
-        crypt.aes_decrypt(args.key)
-    else:
-        crypt.aes_encrypt(args.key)
-
+	def __init__(self, in_filename, out_filename=None):
+		self.in_filename = in_filename
+		self.out_filename = out_filename
+		
+	def aes_encrypt(self, key=None, chunksize=64*1024):
+		self.out_filename = self.out_filename or self.in_filename + '.enc'
+		if key is None:
+			key = base64.b64encode(os.urandom(32))[:32]
+		aes = pyaes.AESModeOfOperationCTR(key)
+		with open(self.in_filename, 'rb') as infile:
+			with open(self.out_filename, 'wb') as outfile:
+				pyaes.encrypt_stream(aes, infile, outfile)
+		return key
+						
+	def aes_decrypt(self, key, chunksize=64*1024):
+		self.out_filename = self.out_filename or os.path.splitext(self.in_filename)[0]
+		aes = pyaes.AESModeOfOperationCTR(key)
+		
+		with open(self.in_filename, 'rb') as infile:
+			with open(self.out_filename, 'wb') as outfile:
+				pyaes.decrypt_stream(aes, infile, outfile)
+				
+				
+if __name__ == '__main__':
+	ap = argparse.ArgumentParser()
+	ap.add_argument(
+		'-k', '--key', action='store', default=None,
+		help='Encrypt/Decrypt Key.',
+		)
+	ap.add_argument(
+		'-d', '--decrypt', action='store_true', default=False,
+		help='Flag to decrypt.',
+		)
+	#ap.add_argument('-t','--type',action='store',choices={'aes','rsa'},default='aes')
+	ap.add_argument('infile', action='store', help='File to encrypt/decrypt.')
+	ap.add_argument('outfile', action='store', nargs='?', help='Output file.')
+	args = ap.parse_args()
+	crypt = Crypt(args.infile, args.outfile)
+	if args.decrypt:
+		crypt.aes_decrypt(args.key)
+	else:
+		nk = crypt.aes_encrypt(args.key)
+		if args.key is None:
+			print "Key: ", nk

--- a/lib/librunner.py
+++ b/lib/librunner.py
@@ -1,0 +1,132 @@
+"""module for running a script in a specific python version"""
+import os
+import sys
+import ctypes
+import base64
+import pickle
+
+
+# TODO:
+# - RPC to _stash (if possible)
+# - killing mechanism
+
+EXE_DIR = os.path.dirname(sys.executable)
+OLD_PY2_FRAMEWORK = "PythonistaKit"
+NEW_PY2_FRAMEWORK = "Py2Kit"
+
+CODE_TEMPLATE = """#Py3 preperation template
+import os
+import sys
+import pickle
+import base64
+import traceback
+
+CWD = "{cwd}"
+CODE = base64.b64decode("{b64c}")  # use b64 to prevent syntax errors
+STDIN_FD = {stdin}
+STDOUT_FD = {stdout}
+STDERR_FD = {stderr}
+
+# prepare I/O
+sys.stdin = open(STDIN_FD, "r")
+sys.stdout = open(STDOUT_FD, "w")
+sys.stderr = open(STDERR_FD, "w")
+
+# prepare env, cwd ...
+os.chdir(CWD)
+
+# prepare scope
+c_globals = pickle.loads(base64.b64decode("{globals}"))
+c_locals = pickle.loads(base64.b64decode("{locals}"))
+
+# execute
+try:
+	exec(CODE, c_globals, c_locals)
+except Exception as e:
+	# only print traceback, so we can close sys.std*
+	traceback.print_exc(file=sys.stderr)
+finally:
+	sys.stdin.close()
+	sys.stdout.close()
+	sys.stderr.close()
+"""
+
+def get_dll(version):
+	"""returns a PyDLL for a specific python version"""
+	if version == 2:
+		for name in (OLD_PY2_FRAMEWORK, NEW_PY2_FRAMEWORK):
+			path = os.path.join(EXE_DIR, "Frameworks", name + ".framework", name)
+			if os.path.exists(path):
+				return ctypes.PyDLL(path)
+		raise RuntimeError("Could not load any Python 2 Framework!")
+	elif version == 3:
+		return ctypes.pythonapi
+	else:
+		raise ValueError("Unknown Python version: '{v}'!".format(v=version))
+
+
+def exec_string(dll, s):
+	"""execute a string with the dll"""
+	state = dll.PyGILState_Ensure()
+	dll.PyRun_SimpleString(s)
+	dll.PyGILState_Release(state)
+
+def exec_string_with_io(dll, s, cwd=None, globals={}, locals={}):
+	"""executes string s using dll and return stdin, stdout, stderr"""
+	if cwd is None:
+		cwd = os.getcwd()
+	inr, inw = os.pipe()
+	outr, outw = os.pipe()
+	excr, excw = os.pipe()
+	stdin = os.fdopen(inw, "w")
+	stdout = os.fdopen(outr, "r")
+	stderr = os.fdopen(excr, "r")
+	filled_t = CODE_TEMPLATE.format(
+		b64c=base64.b64encode(s),
+		cwd=cwd,
+		stdin=inr,
+		stdout=outw,
+		stderr=excw,
+		globals=base64.b64encode(pickle.dumps(globals)),
+		locals=base64.b64encode(pickle.dumps(locals)),
+		)
+	exec_string(dll, filled_t)
+	return stdin, stdout, stderr
+
+
+def _test():
+	# test code. status message are UPPERCASE to see test starts/end easier
+	dll3 = get_dll(3)
+	# 1. syntax error print
+	sys.stdout.write("STARTING SYNTAX ERROR TEST PY3...\n")
+	i, o, e = exec_string_with_io(dll3, "print 'this should be an error in py3'")
+	sys.stdout.write("READING STDOUT (expected empty)...\n")
+	sys.stdout.write(o.read(2048)+"\n")
+	sys.stdout.write("READING STDERR (expected traceback)...\n")
+	sys.stdout.write(e.read(4096)+"\n")
+	sys.stdout.write("CLOSING I/O...\n")
+	i.close()
+	o.close()
+	e.close()
+	sys.stdout.write("\nSYNTAX ERROR TEST FINISHED\n")
+	# 2. echo test
+	sys.stdout.write("STARTING ECHO TEST...\n")
+	i, o, e = exec_string_with_io(
+		dll3,
+		"print(input('Hello, what is your name?').uppercase())",
+		)
+	sys.stdout.write("READING STDOUT (expected prompt)...\n")
+	sys.stdout.write(o.read(2048)+"\n")
+	sys.stdout.write("READING STDERR (expected empty)...\n")
+	sys.stdout.write(e.read(4096)+"\n")
+	sys.stdout.write("PLEASE ENTER A STRING TO SEND TO STDIN:\n")
+	i.write(sys.stdin.readline())
+	sys.stdout.write("CLOSING I/O...\n")
+	i.close()
+	o.close()
+	e.close()
+	sys.stdout.write("\nSYNTAX ERROR TEST FINISHED\n")
+
+
+if __name__ == "__main__":
+	_test()

--- a/lib/mlpatches/base.py
+++ b/lib/mlpatches/base.py
@@ -39,6 +39,7 @@ class BasePatch(object):
 				raise IncompatiblePatch("Python 2 not supported!")
 			if pyv == 3 and not self.PY3:
 				raise IncompatiblePatch("Python 3 not supported!")
+			self.pre_enable()
 			self.do_enable()
 			self.enabled = True
 	
@@ -54,6 +55,10 @@ class BasePatch(object):
 	
 	def do_disable(self):
 		"""This should be overwritten in subclasses and remove the patch."""
+		pass
+	
+	def pre_enable(self):
+		"""this will be called between enable() and do_enable()."""
 		pass
 
 
@@ -145,6 +150,7 @@ class PatchGroup(BasePatch):
 	def enable(self):
 		# we need to overwrite enable() because
 		# the patches should check wether they are already enabled
+		self.pre_enable()
 		self.do_enable()
 	
 	def disable(self):

--- a/lib/mlpatches/modules/subprocess.py
+++ b/lib/mlpatches/modules/subprocess.py
@@ -96,7 +96,7 @@ class Popen(object):
 		else:
 			if args[0] == sys.executable:
 				# common use case
-				args = ["python"] + list(args)
+				args = ["python"] + list(args)[1:]
 			self.cmd = l2c.list2cmdline(args)
 
 		# === setup std* ===
@@ -146,15 +146,15 @@ class Popen(object):
 		
 		# setup stdin
 		if stdin is None:
-			# use own stdout
+			# use own stdin
 			self.stdin = None
 			self._sp_stdin = None
 		elif stdin == PIPE:
 			# create new pipe
 			rfd, wfd = os.pipe()
 			self._fds += [rfd, wfd]
-			self.stdin = os.fdopen(rfd, "wb")
-			self._sp_stdin = os.fdopen(wfd, "rb")
+			self.stdin = os.fdopen(wfd, "wb")
+			self._sp_stdin = os.fdopen(rfd, "rb")
 		elif isinstance(stdin, (int, long)):
 			# use fd
 			self.stdin = None

--- a/lib/mlpatches/mount_patches.py
+++ b/lib/mlpatches/mount_patches.py
@@ -1,6 +1,7 @@
 """This module contains the group definition for the mount patches."""
 from mlpatches.base import PatchGroup
 from mlpatches import mount_base
+from stashutils import mount_ctrl
 
 _BASE_PATCHES = filter(
 	None,
@@ -15,6 +16,14 @@ class MountPatches(PatchGroup):
 	patches = [
 		
 		] + _BASE_PATCHES
+	
+	def pre_enable(self):
+		# ensure a manager is set
+		manager = mount_ctrl.get_manager()
+		if manager is None:
+			from stashutils import mount_manager  # import here to prevent an error
+			manager = mount_manager.MountManager()
+			mount_ctrl.set_manager(manager)
 
 
 # create patchgroup instances

--- a/lib/stashutils/mount_manager.py
+++ b/lib/stashutils/mount_manager.py
@@ -4,7 +4,7 @@ import os
 from stashutils.core import get_stash
 from stashutils.fsi.base import BaseFSI
 from stashutils.fsi.errors import OperationFailure
-from stashutils.mount_ctrl import set_manager
+from stashutils.mount_ctrl import set_manager, get_manager
 
 from mlpatches.mount_patches import MOUNT_PATCHES
 
@@ -99,4 +99,5 @@ class MountManager(object):
 
 # install manager
 
-set_manager(MountManager())
+if get_manager() is None:
+	set_manager(MountManager())


### PR DESCRIPTION
This pull-request contains these changes and bugfixes:

- `crypt.py` now uses `pyaes` instead of `simplecrypto`. While `pyaes` is a bit slower, it is 100% python. **This change is backwards incompatible!** I changed the AES mode from `CFB` to `CTR`. Due to this, it is no longer possible to decrypt files encrypted with the old `crypt` command. It *would* be possible to make `crypt` backward compatible, but there are also some reasons to do this change. For example, the `CFB` mode requires an initlaization vector (unlike `CTR`). Looking at the sourcecode of `simplecrypto`, this was appended in front of the file. I am not sure wether that would be the most inter-implementation compatible way. There were also some other changes. Maybe we should add a `--compatibility` argument to `crypt`?
- fixed a bug in the monkeypatch for `subprocess`. This was a few months ago, so i am not sure anymore what that bug did.

This puill-request also contains an unfinished version of `librunner.py` (the module for running py3 from py2). I am not sure in which state it is, but unfortunately i dont have the time to continue working on it (at least not now).
