### PR TITLE
Relative file handling for git add.

### DIFF
--- a/bin/git.py
+++ b/bin/git.py
@@ -285,8 +285,10 @@ def git_add(args):
 
         args = [os.path.join(os.path.relpath(cwd, repo.path), x)
                     if not os.path.samefile(cwd, repo.path) else x for x in args]
+       
         for file in args:
-            if os.path.exists(file):
+            
+            if os.path.exists(os.path.join(repo.repo.path, file)):
                 print 'Adding {0}'.format(file)
                 porcelain.add(repo.repo.path, [file])
             else:


### PR DESCRIPTION
Bugfix.  Adds relative path support to the file path check when performing a git add.

Current behavior: 

```
[bin]$ git add git.py
bin/git.py does not exist. skipping
[bin]$ cd ..
[stash-dev]$ git add git.py
git.py does not exist. skipping
[stash-dev]$ git add bin/git.py
Adding bin/git.py
```

New behavior.  The relative add now works as expected: 
```
[bin]$ git add git.py
Adding bin/git.py
[bin]$ cd ..
[stash-dev]$ git add git.py
git.py does not exist. skipping
[stash-dev]$ git add bin/git.py
Adding bin/git.py
```
