### PR TITLE
fix TypeError on `git push git+ssh://...

### DIFF
--- a/bin/git.py
+++ b/bin/git.py
@@ -586,7 +586,7 @@ def git_push(args):
         porcelain.push(repo.repo.path, result.url, branch_name, errstream=outstream)
  
     for line in outstream.getvalue().split('\n'):
-            print(line.replace(pw, '*******'))
+        print(line.replace(pw, '*******') if pw else line)
     
     print 'success!'
 


### PR DESCRIPTION
`git push` produces TypeError if the password is not set (if ssh keys are used):

```[test-git]$ git push
Attempting to push to: git+ssh://user@gitserver/home/user/.bare-repos/test-git.git, branch: refs/heads/master
stash: <type 'exceptions.TypeError'>: expected a string or other character buffer object
```

The breaking change was introduced in 666aa496e1045e0c50e64c54fd0ce7b7e7050c4c in #238 