### PR TITLE
XML-RPC replacement #264

### DIFF
--- a/bin/pip.py
+++ b/bin/pip.py
@@ -903,6 +903,7 @@ class PyPIRepository(PackageRepository):
         if not r.status_code == requests.codes.ok:
             raise PipError('Failed to fetch package releases')
 
+        # _determin_hit expects latest first, sort them by versions
         tuples = [release.split('.') for release in r.json()['releases'].keys()]
         tuples = sorted(tuples, reverse=True)
         return ['.'.join(release) for release in tuples]

--- a/bin/pip.py
+++ b/bin/pip.py
@@ -872,7 +872,7 @@ class PyPIRepository(PackageRepository):
     def __init__(self):
         super(PyPIRepository, self).__init__()
         import xmlrpclib
-        # DO NOT USE self.pypi, it's there just for search
+        # DO NOT USE self.pypi, it's there just for search, it's obsolete/legacy
         self.pypi = xmlrpclib.ServerProxy('https://pypi.python.org/pypi')
         self.standard_package_names = {}
 


### PR DESCRIPTION
Replaces XML-RPC calls in pip, except package search. Can't find any endpoint and it looks like that people recommends to list simplified index and search in it. Time consuming, not an ideal solution, ... I think that we can live with XML-RPC & search for now. Package is listed immediately and rest is done via JSON.