### PR TITLE
Redesigned test 102

### DIFF
--- a/system/tests/data/test_102_1.py
+++ b/system/tests/data/test_102_1.py
@@ -5,4 +5,4 @@ import time
 
 for i in range(5):
     print '{}'.format(os.path.basename(__file__))
-    time.sleep(1)
+    time.sleep(.5)

--- a/system/tests/data/test_102_2.py
+++ b/system/tests/data/test_102_2.py
@@ -4,4 +4,4 @@ import time
 
 for i in range(5):
     print '{}'.format(os.path.basename(__file__))
-    time.sleep(1)
+    time.sleep(.5)

--- a/system/tests/test_threads.py
+++ b/system/tests/test_threads.py
@@ -37,9 +37,20 @@ sleeping ... 1
         outs = StringIO()
         self.stash('test_102_1.py &', final_outs=outs)
         self.stash('test_102_2.py &', final_outs=outs)
-        time.sleep(7)
+        time.sleep(5)
         s = outs.getvalue()
-        assert 0 < s.find('test_102_2.py') < len(s)/2, 'Output do not interleave'
+
+        # Count the number of times the output switches between threads
+        change_cnt = 0
+        prev_line = None
+        for cur_line in outs.getvalue().splitlines():
+            if prev_line is None: 
+                prev_line = cur_line
+            elif prev_line != cur_line:
+                change_cnt += 1
+                prev_line = cur_line
+        
+        self.assertTrue(change_cnt > 2, 'Output do not interleave')
 
     def test_103(self):
         """
@@ -66,6 +77,3 @@ test_102_1.py
 test_102_1.py
 """
         assert outs1.getvalue() == cmp_str2, 'output not identical'
-
-
-


### PR DESCRIPTION
@ywangd I've tracked down the intermittent CI failures with test 102.  When thread_102_2.py successfully executes first, the resulting output in s begins with "thread_102_2.py".  For this scenario, the original test_102 assertion "find()" was returning "0" (the first position) causing the test to be 0 < 0.  This PR redesigns test 102 to count the number of times the output actually switches between the threads, and defines a minimum number of times we should see it switch.

The selection of "> 2" as the target number of switches was somewhat arbitrary.  My thinking was we at least want to avoid a false pass test pattern of AAAAABBBBB.  In reality, with the way the tests are structured, we should see ABABABABAB (9 changes), but this is not a guarantee.  