### PR TITLE
Honor ~/.gitconfig for git user name, email

### DIFF
--- a/bin/git.py
+++ b/bin/git.py
@@ -388,7 +388,7 @@ def git_reset(args):
                 f.write(file_contents)
 
 def get_config_or_prompt(repo, section, name, prompt, save=None):
-    config = repo.repo.get_config()
+    config = repo.repo.get_config_stack()
     try:
         value = config.get(section, name)
     except KeyError:


### PR DESCRIPTION
 Don't ask for user name, email on the first git commit if they are already specified in the global user config: `~/.gitconfig`.