### PR TITLE
Start testing on Python 3 in allow_failures mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,19 @@
 language: python
 python:
   - "2.7"
+  - "3.6"
+matrix:
+  allow_failures:
+    - python: "3.6"
 # command to install dependencies
 install:
   - "pip install pyparsing==2.0.1"
+  - "pip install pytest>=2.8.1"
+  - "pip install flake8>=3.5.0"
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 # command to run tests
-script: python testing.py -v
+script: py.test system/tests --ignore=system/tests/data

--- a/bin/clear.py
+++ b/bin/clear.py
@@ -1,2 +1,3 @@
 """Clear the stash console output window"""
+_stash = globals()['_stash']
 _stash.term.truncate(size=0)

--- a/bin/cp.py
+++ b/bin/cp.py
@@ -7,6 +7,8 @@ from __future__ import print_function
 import argparse
 import os
 import shutil
+import sys
+
 
 def pprint(path):
     if path.startswith(os.environ['HOME']):
@@ -18,7 +20,7 @@ def main(args):
     ap.add_argument('source', nargs='+', help='one or more files or directories to be copied')
     ap.add_argument('dest', help='destination file or folder')
     ns = ap.parse_args(args)
-    
+
     files = ns.source
     dest = ns.dest
 
@@ -30,7 +32,7 @@ def main(args):
                 full_file = os.path.abspath(filef)
                 file_name = os.path.basename(full_file)
                 new_name  = os.path.join(full_dest, file_name)
-                
+
                 try:
                     if os.path.isdir(full_file):
                         shutil.copytree(full_file, new_name)

--- a/bin/crypt.py
+++ b/bin/crypt.py
@@ -19,22 +19,22 @@ try:
     from simplecrypto.key import AesKey
 except:
     print 'Installing Required packages.'
-    _stash('pip install simplecrypto')
+    _stash('pip install simplecrypto')  # noqa: F821 undefined name
     sys.exit(0)
 
 class Crypt(object):
     def __init__(self,in_filename,out_filename=None):
         self.in_filename = in_filename
         self.out_filename = out_filename
-        
+
     def aes_encrypt(self,key=None, chunksize=64*1024):
         self.out_filename = self.out_filename or self.in_filename+'.enc'
         aes = AesKey(key)
         with open(self.in_filename, 'rb') as infile:
             with open(self.out_filename, 'wb') as outfile:
                 outfile.write(aes.encrypt_raw(infile.read()))
-            
-        
+
+
     def aes_decrypt(self,key, chunksize=64*1024):
         self.out_filename = self.out_filename or os.path.splitext(self.in_filename)[0]
         aes = AesKey(key)
@@ -43,8 +43,9 @@ class Crypt(object):
             with open(self.out_filename, 'wb') as outfile:
                 outfile.write(aes.decrypt_raw(infile.read()))
 
-            
+
 if __name__=='__main__':
+    import argparse
     ap = argparse.ArgumentParser()
     ap.add_argument('-k','--key',action='store',default='',help='Encrypt/Decrypt Key.')
     ap.add_argument('-d','--decrypt',action='store_true',default=False,help='Flag to decrypt.')
@@ -57,4 +58,3 @@ if __name__=='__main__':
         crypt.aes_decrypt(args.key)
     else:
         crypt.aes_encrypt(args.key)
-

--- a/bin/git.py
+++ b/bin/git.py
@@ -16,21 +16,21 @@ commands:
     pull: git pull [http(s)://<remote repo>] - pull changes from a remote repository
     checkout: git checkout <branch> - check out a particular branch in the Git tree
     branch: git branch - show branches
-    remote: git remote - list remote repos 
+    remote: git remote - list remote repos
     status: git status - show status of files (staged unstaged untracked)
     reset: git reset - reset a repo to its pre-change state
     help: git help
 '''
 
-SAVE_PASSWORDS = True
-
 import argparse
-import getpass
+import console
 import urlparse,urllib2,keychain
 import sys,os
 
 # temporary -- install required modules
 
+_stash = globals()['_stash']
+SAVE_PASSWORDS = True
 GITTLE_URL='https://github.com/jsbain/gittle/archive/master.zip'
 FUNKY_URL='https://github.com/FriendCode/funky/archive/master.zip'
 DULWICH_URL='https://github.com/transistor1/dulwich/archive/master.zip'
@@ -39,20 +39,20 @@ if True:
     libpath=os.path.join(_stash.runtime.envars['STASH_ROOT'] ,'lib')
     if not libpath in sys.path:
         sys.path.insert(1,libpath)
-    try:  
+    try:
         from dulwich.client import default_user_agent_string
         from dulwich import porcelain
-    
+
     except ImportError:
         _stash('wget {} -o $TMPDIR/dulwich.zip'.format(DULWICH_URL))
         _stash('unzip $TMPDIR/dulwich.zip -d $TMPDIR/dulwich')
         _stash('mv $TMPDIR/dulwich/dulwich $STASH_ROOT/lib/')
         _stash('rm  $TMPDIR/dulwich.zip')
         _stash('rm -r $TMPDIR/dulwich')
-    
+
         from dulwich import porcelain
         from dulwich.client import default_user_agent_string
-    
+
     try:
         gittle_path=os.path.join(libpath,'gittle')
         funky_path=os.path.join(libpath,'funky')
@@ -99,7 +99,7 @@ command_help={    'init':  'initialize a new Git repository'
           }
 
 
-    
+
     #Find a git repo dir
 def _find_repo(path):
     subdirs = os.walk(path).next()[1]
@@ -195,7 +195,7 @@ def git_commit(args):
         ns.name=raw_input('Author Name:')
     if not ns.email:
         ns.email=raw_input('Author Email')
-     
+
     try:
         repo = _get_repo()
         author = "{0} <{1}>".format(ns.name, ns.email)
@@ -342,7 +342,7 @@ def git_help(args):
     print 'help:'
     for key, value in command_help.items():
         print value
-            
+
 #Urllib2 opener for dulwich
 def auth_urllib2_opener(config, top_level_url, username, password):
     if config is not None:

--- a/bin/scp.py
+++ b/bin/scp.py
@@ -5,7 +5,7 @@ Copies files from local to remote
 usage:
     GET
     scp [user@host:dir/file] [files/dir]
-    
+
     PUT
     scp [file/dir] [file/dir] [user@host:dir]
 '''
@@ -461,16 +461,13 @@ class SCPClient(object):
 class SCPException(Exception):
     """SCP exception class"""
     pass
-    
+
 ############################################
-def find_ssh_keys():
+def find_ssh_keys(base_dir=os.environ['STASH_ROOT']):
     #dir = os.path.expanduser('~/Documents/.ssh/')
-    files = []
-    for file in os.listdir(APP_DIR+'/.ssh'):
-        if '.' not in file:
-            files.append(APP_DIR+'/.ssh/'+file)
-    return files    
-    
+    ssh_path = os.path.join(base_dir, '.ssh')
+    return [ssh_path + file for file in os.listdir(ssh_path)]
+
 def parse_host(arg):
     user,temp = arg.split('@')
     host, path = temp.split(':')
@@ -479,28 +476,28 @@ def parse_host(arg):
 def scp_callback(filename, size, sent):
     if size == sent:
         print filename
-    
+
 
 if __name__ == '__main__':
     from paramiko import SSHClient, AutoAddPolicy
     files = []
-    
+
     ap = argparse.ArgumentParser()
     ap.add_argument('files',nargs='*', help='file or module name')
     args = ap.parse_args()
-    
+
     #scp_mode 0 put 1 get
     if '@' in args.files[0]:
-        scp_mode = 1   
+        scp_mode = 1
     else:
         scp_mode = 0
-        
+
     for file in args.files:
         if '@' in file:
             host,user,host_path = parse_host(file)
         else:
             files.append(file)
-            
+
     ssh = SSHClient()
     #ssh.load_system_host_keys()
     ssh.set_missing_host_key_policy(AutoAddPolicy())
@@ -513,10 +510,7 @@ if __name__ == '__main__':
     if scp_mode:
         print 'Copying from server...'
         scp.get(host_path, local_path=files[0], recursive=True)
-        
+
     else:
         print 'Copying to server...'
         scp.put(files, recursive=True, remote_path=host_path)
-
-
-

--- a/bin/ssh-keygen.py
+++ b/bin/ssh-keygen.py
@@ -14,11 +14,10 @@ import argparse
 import paramiko
 #import patchparamiko
 
-
+APP_DIR = os.environ['STASH_ROOT']
 key_mode = {'rsa': 'rsa',
             'dsa': 'dss'}
 
-            
 ap = argparse.ArgumentParser()
 ap.add_argument('-t',choices=('rsa','dsa'), action='store',dest='type', help='Key Type: (rsa,dsa)')
 ap.add_argument('-b', action='store',dest='bits', default=1024, type=int, help='bits for key gen. default: 1024')
@@ -29,7 +28,7 @@ args = ap.parse_args()
 #Keygen for keypair
 if not os.path.isdir(APP_DIR+'/.ssh'):
     os.mkdir(APP_DIR+'/.ssh')
-    
+
 try:
     k = False
     if args.type == 'rsa':

--- a/tests/test05.py
+++ b/tests/test05.py
@@ -1,4 +1,4 @@
-s = _stash
+s = globals()['_stash']
 
 # following statements should be correlated
 s('echo AA is $AA')


### PR DESCRIPTION
It is time to make sure that StaSH can make the transition to Python 3.
* Add flake8 tests in the __before_script__.
* Resolve Python 2 undefined names (flake8 F821)
* Remove a few unused imports
* Simplify __find_ssh_keys()__ in scp.py
* My editor (Atom) automatically removes trailing whitespace
