### PR TITLE
Start testing on Python 3 in allow_failures mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,19 @@
 language: python
 python:
   - "2.7"
+  - "3.6"
+matrix:
+  allow_failures:
+    - python: "3.6"
 # command to install dependencies
 install:
   - "pip install pyparsing==2.0.1"
-  - "pip install pytest>=2.8.1"
+  - "pip install pytest>=3.5.0"
+  - "pip install flake8>=3.5.0"
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 # command to run tests
 script: py.test system/tests --ignore=system/tests/data

--- a/bin/cp.py
+++ b/bin/cp.py
@@ -7,6 +7,8 @@ from __future__ import print_function
 import argparse
 import os
 import shutil
+import sys
+
 
 def pprint(path):
     if path.startswith(os.environ['HOME']):

--- a/bin/crypt.py
+++ b/bin/crypt.py
@@ -13,10 +13,11 @@ optional arguments:
   -k KEY, --key KEY  Encrypt/Decrypt Key.
   -d, --decrypt      Flag to decrypt.
 '''
-import os
 import argparse
 import base64
+import os
 
+_stash = globals()['_stash']
 try:
 	import pyaes
 except:

--- a/bin/gh.py
+++ b/bin/gh.py
@@ -13,6 +13,10 @@ For all commands, use gh <command> --help for more detailed help
 NOTE: assumes a keychain user/pass stored in 	keychainservice='stash.git.github.com', which is also the default from the git module.  
 
 '''
+import os
+import sys
+
+
 def install_module_from_github(username, package_name, folder, version):
     """
     Install python module from github zip files

--- a/bin/git.py
+++ b/bin/git.py
@@ -23,16 +23,21 @@ Commands:
     help: git help
 '''
 
-SAVE_PASSWORDS = True
-
 import argparse
-import urlparse,urllib2,keychain
-import sys,os,posix
-import editor #for reloading current file
+import os
+import posix
+import subprocess
+import sys
+import urlparse
+from StringIO import StringIO
+
+import console
+import editor  # for reloading current file
+import keychain
+
 # temporary -- install required modules
 
-#needed for dulwich: subprocess needs to have Popen
-import subprocess
+# needed for dulwich: subprocess needs to have Popen
 if not hasattr(subprocess,'call'):
 	def Popen(*args,**kwargs):
 		pass
@@ -40,6 +45,9 @@ if not hasattr(subprocess,'call'):
 		return 0
 	subprocess.Popen=Popen
 	subprocess.call=call
+
+_stash = globals()['_stash']
+SAVE_PASSWORDS = True
 GITTLE_URL='https://github.com/jsbain/gittle/archive/master.zip'
 FUNKY_URL='https://github.com/FriendCode/funky/archive/master.zip'
 DULWICH_URL='https://github.com/jsbain/dulwich/archive/ForStaSH_0.12.2.zip'

--- a/bin/grep.py
+++ b/bin/grep.py
@@ -9,6 +9,7 @@ import re
 import sys
 
 def main(args):
+    global _stash
     ap = argparse.ArgumentParser()
     ap.add_argument('pattern', help='the pattern to match')
     ap.add_argument('files', nargs='*', help='files to be searched')

--- a/bin/latte.py
+++ b/bin/latte.py
@@ -104,7 +104,7 @@ def main(sargs):
 		try:
 			download_package(repo_to_use, package_name)
 		except:
-			stoutput("ERROR", "Couldn't find package", "error")
+			print("ERROR", "Couldn't find package", "error")
 			sys.exit()
 		# Move to correct locations
 		print("Installing")

--- a/bin/mail.py
+++ b/bin/mail.py
@@ -67,6 +67,7 @@ class Mail(object):
         self.tls      = parser.get('mail','tls')
             
     def edit_cfg(self):
+        global _stash
         _stash('edit -t %s' %self.cfg_file)
         sys.exit(0)
         

--- a/bin/which.py
+++ b/bin/which.py
@@ -3,6 +3,8 @@
 
 import argparse
 
+_stash = globals()['_stash']
+
 
 def main(command, fullname=False):
     rt = globals()['_stash'].runtime
@@ -13,6 +15,7 @@ def main(command, fullname=False):
         print filename
     except Exception:
         pass
+
 
 if __name__ == '__main__':
     ap = argparse.ArgumentParser()

--- a/lib/git/git-merge.py
+++ b/lib/git/git-merge.py
@@ -1,12 +1,14 @@
 
-from dulwich.diff_tree import _tree_entries, _NULL_ENTRY, TreeEntry, _is_tree
-from gittle import Gittle
-from dulwich import porcelain
-import stat
-from git import diff3
-from git.gitutils import _get_repo, find_revision_sha, can_ff, merge_base, count_commits_between, is_ancestor, get_remote_tracking_branch, GitError
 import argparse
+import os
+import stat
 
+from dulwich import porcelain
+from dulwich.diff_tree import _NULL_ENTRY, TreeEntry, _is_tree, _tree_entries
+from git import diff3, git_reset
+from git.gitutils import (GitError, _get_repo, count_commits_between,
+                          find_revision_sha, get_remote_tracking_branch,
+                          merge_base)
 
 
 def _merge_entries(path, trees):


### PR DESCRIPTION
It is time to make sure that StaSH can make the transition to Python 3.
* Add flake8 tests in the Travis CI __before_script__.
* Resolve Python 2 undefined names (flake8 F821)
* Remove a few unused imports
* ~~My editor (Atom) automatically removes trailing whitespace~~
* Propose a solution to #296

Replaces both #293 and #294

@jsbain @zrzka @dgelessus Your reviews please