### PR TITLE
make stash py3 compatible

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,1 @@
-
+from . import core as stash

--- a/bin/cd.py
+++ b/bin/cd.py
@@ -14,7 +14,7 @@ import sys
 def main(args):
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("dir", action="store", nargs="?",
-                   default=os.environ["HOME2"], type=str,
+                   default=os.environ["HOME2"],
                    help="the new working directory")
     ns = p.parse_args(args)
 

--- a/bin/clear.py
+++ b/bin/clear.py
@@ -1,2 +1,4 @@
 """Clear the stash console output window"""
-print u'\u009bc',
+# TODO: prevent linebreak after 0099bc
+# This was removed as a quick fix
+print(u'\u009bc')

--- a/bin/crypt.py
+++ b/bin/crypt.py
@@ -20,7 +20,7 @@ import base64
 try:
 	import pyaes
 except:
-	print 'Installing Required packages.'
+	print('Installing Required packages...')
 	_stash('pip install pyaes')
 	import pyaes
 
@@ -69,4 +69,4 @@ if __name__ == '__main__':
 	else:
 		nk = crypt.aes_encrypt(args.key)
 		if args.key is None:
-			print "Key: ", nk
+			print("Key: %s" % nk)

--- a/bin/curl.py
+++ b/bin/curl.py
@@ -35,14 +35,14 @@ def main(args):
     elif ns.request_method == 'HEAD':
         r = requests.head(url, headers=headers)
     else:
-        print 'unknown request method: {}'.format(ns.request_method)
+        print('unknown request method: {}'.format(ns.request_method))
         return
 
     if ns.output_file:
         with open(ns.output_file, 'w') as outs:
             outs.write(r.text)
     else:
-        print r.text
+        print(r.text)
 
 
 if __name__ == '__main__':

--- a/bin/cut.py
+++ b/bin/cut.py
@@ -41,15 +41,15 @@ def main(args):
     for infields in _stash.libcore.input_stream(ns.files):
         if infields[0] is None:
             _, filename, e = infields
-            print '%s: %s' % (filename, repr(e))
+            print('%s: %s' % (filename, repr(e)))
         else:
             line, filename, lineno = infields
             fields = line.split(ns.delimiter)
             if len(fields) == 1:
-                print fields[0]
+                print(fields[0])
             else:
                 out = ' '.join((' '.join(fields[sidx:eidx]) for sidx, eidx in indices))
-                print out
+                print(out)
 
 if __name__ == '__main__':
     main(sys.argv[1:])

--- a/bin/dropbox_setup.py
+++ b/bin/dropbox_setup.py
@@ -28,11 +28,11 @@ class DropboxSetupCmd(cmd.Cmd):
 
 	def do_list(self, cmd):
 		"""list: lists the dropbox usernames."""
-		print
+		self.stdout.write("\n")
 		for service, account in keychain.get_services():
 			if service == dbutils.DB_SERVICE:
-				print account
-		print
+				self.stdout.write(account + "\n")
+		self.stdout.write("\n")
 
 	def do_del(self, cmd):
 		"""del USERNAME: resets the dropbox for USERNAME."""

--- a/bin/du.py
+++ b/bin/du.py
@@ -71,9 +71,9 @@ def main(args):
                 if ns.summarize and root != path:
                     continue
 
-                print '%-8s %s' % (sizeof_fmt(my_size), root)
+                print('%-8s %s' % (sizeof_fmt(my_size), root))
         else:
-            print '%-8s %s' % (sizeof_fmt(os.path.getsize(path)), path)
+            print('%-8s %s' % (sizeof_fmt(os.path.getsize(path)), path))
 
 
 if __name__ == '__main__':

--- a/bin/edit.py
+++ b/bin/edit.py
@@ -14,6 +14,10 @@ import editor
 import time
 import argparse
 
+_stash = globals()["_stash"]
+
+if _stash.PY3:
+	raw_input = input
 
 def open_temp(file='', new_tab=True):
     try:
@@ -30,7 +34,7 @@ def open_temp(file='', new_tab=True):
             temp.flush()
             to_edit.close()
             
-        print '***When you are finished editing the file, you must come back to console to confim changes***'
+        print('***When you are finished editing the file, you must come back to console to confim changes***')
         editor.open_file(temp.name, new_tab)
         time.sleep(1.5)
         console.hide_output()
@@ -51,13 +55,13 @@ def open_temp(file='', new_tab=True):
                 with open(temp.name,'r') as tmp:
                     f.write(tmp.read())
                     
-            print 'File Saved.'
+            print('File Saved.')
         elif input=='N' or input=='n':
             if not new_tab:
                 editor.open_file(cur_path) # restore previous script in editor
     
-    except Exception, e:
-        print e
+    except Exception as e:
+        print(e)
         
     finally:
         temp.close()

--- a/bin/fg.py
+++ b/bin/fg.py
@@ -20,17 +20,16 @@ def main(args):
         worker = worker_registry.get_worker(ns.job_id)
 
     if worker is None:
-        print 'no background job running' \
-              + (' with id {}'.format(ns.job_id) if ns.job_id else '')
+        print('no background job running' \
+              + (' with id {}'.format(ns.job_id) if ns.job_id else ''))
         return
 
     def f():
         _stash.runtime.push_to_foreground(worker)
 
     t = threading.Timer(1.0, f)
-    print 'pushing job {} to foreground ...'.format(worker.job_id)
+    print('pushing job {} to foreground ...'.format(worker.job_id))
     t.start()
 
 if __name__ == '__main__':
     main(sys.argv[1:])
-

--- a/bin/jobs.py
+++ b/bin/jobs.py
@@ -16,7 +16,7 @@ def main(args):
 
     for worker in _stash.get_workers():
         if worker.job_id != current_worker.job_id:
-            print worker
+            print(worker)
 
 
 if __name__ == '__main__':

--- a/bin/kill.py
+++ b/bin/kill.py
@@ -16,16 +16,15 @@ def main(args):
 
     for job_id in ns.job_ids:
         if job_id in _stash.runtime.worker_registry:
-            print 'killing job {} ...'.format(job_id)
+            print('killing job {} ...'.format(job_id))
             worker = _stash.runtime.worker_registry.get_worker(job_id)
             worker.kill()
             time.sleep(1)
 
         else:
-            print 'error: no such job with id: {}'.format(job_id)
+            print('error: no such job with id: {}'.format(job_id))
             break
 
 
 if __name__ == '__main__':
     main(sys.argv[1:])
-

--- a/bin/ls.py
+++ b/bin/ls.py
@@ -124,7 +124,7 @@ def main(args):
 
     if len(ns.files) == 0:
         out = joiner.join(_fmt(f) for f in os.listdir('.') if _filter(f))
-        print out
+        print(out)
 
     else:
         out_dir = []
@@ -142,12 +142,12 @@ def main(args):
                 out_file.append(_fmt(f))
 
         for o in out_miss:
-            print o
-        print joiner.join(out_file)
+            print(o)
+        print(joiner.join(out_file))
         if out_file:
-            print
+            print("")
         for o in out_dir:
-            print o
+            print(o)
     sys.exit(exitcode)
 
 

--- a/bin/pip.py
+++ b/bin/pip.py
@@ -26,6 +26,7 @@ import contextlib
 import requests
 import re
 import operator
+import traceback
 
 import six
 from distutils.util import convert_path
@@ -51,11 +52,19 @@ PACKAGE_NAME_FIXER = {
     'lazy_object_proxy': 'lazy-object-proxy',
 }
 
-SITE_PACKAGES_FOLDER = os.path.expanduser('~/Documents/site-packages')
+_stash = globals()['_stash']
+
+if _stash.PY3:
+    unicode = str
+    str = bytes
+    SITE_PACKAGES_DIR_NAME = 'site-packages-3'
+else:
+    SITE_PACKAGES_DIR_NAME = 'site-packages-2'
+
+SITE_PACKAGES_FOLDER = os.path.expanduser('~/Documents/{}'.format(SITE_PACKAGES_DIR_NAME))
 
 NO_OVERWRITE = False
 
-_stash = globals()['_stash']
 
 
 def _setup_stub_(*args, **kwargs):
@@ -145,9 +154,9 @@ class PackageFinder(object):
     def _find_packages_iter(cls, base_path):
         candidates = cls._candidate_dirs(base_path)
         return (
-            path.replace(os.path.sep, '.')
-            for path in candidates
-            if cls._looks_like_package(os.path.join(base_path, path))
+        path.replace(os.path.sep, '.')
+        for path in candidates
+        if cls._looks_like_package(os.path.join(base_path, path))
         )
 
     @staticmethod
@@ -211,48 +220,48 @@ def fake_setuptools_modules():
     Created a bunch of stub setuptools modules
     """
     setuptools_modules = [
-        'setuptools',
-        'setuptools.command',
-        'setuptools.command.alias',
-        'setuptools.command.bdist_egg',
-        'setuptools.command.bdist_rpm',
-        'setuptools.command.bdist_wininst',
-        'setuptools.command.build_ext',
-        'setuptools.command.build_py',
-        'setuptools.command.develop',
-        'setuptools.command.easy_install',
-        'setuptools.command.egg_info',
-        'setuptools.command.install',
-        'setuptools.depends.install_egg_info',
-        'setuptools.command.install_lib',
-        'setuptools.command.install_scripts',
-        'setuptools.command.register',
-        'setuptools.command.rotate',
-        'setuptools.command.saveopts',
-        'setuptools.command.sdist',
-        'setuptools.command.setopt',
-        'setuptools.command.test',
-        'setuptools.command.upload',
-        'setuptools.command.upload_docs',
-        'setuptools.extern',
-        'setuptools.dist',
-        'setuptools.extension',
-        'setuptools.launch',
-        'setuptools.lib2to3_ex',
-        'setuptools.msvc9_support',
-        'setuptools.package_index',
-        'setuptools.py26compat',
-        'setuptools.py27compat',
-        'setuptools.py31compat',
-        'setuptools.sandbox',
-        'setuptools.site-patch',
-        'setuptools.ssl_support',
-        'setuptools.unicode_utils',
-        'setuptools.utils',
-        'setuptools.version',
-        'setuptools.windows_support',
-        # 'pkg_resources',
-        # 'pkg_resources.extern',
+    'setuptools',
+    'setuptools.command',
+    'setuptools.command.alias',
+    'setuptools.command.bdist_egg',
+    'setuptools.command.bdist_rpm',
+    'setuptools.command.bdist_wininst',
+    'setuptools.command.build_ext',
+    'setuptools.command.build_py',
+    'setuptools.command.develop',
+    'setuptools.command.easy_install',
+    'setuptools.command.egg_info',
+    'setuptools.command.install',
+    'setuptools.depends.install_egg_info',
+    'setuptools.command.install_lib',
+    'setuptools.command.install_scripts',
+    'setuptools.command.register',
+    'setuptools.command.rotate',
+    'setuptools.command.saveopts',
+    'setuptools.command.sdist',
+    'setuptools.command.setopt',
+    'setuptools.command.test',
+    'setuptools.command.upload',
+    'setuptools.command.upload_docs',
+    'setuptools.extern',
+    'setuptools.dist',
+    'setuptools.extension',
+    'setuptools.launch',
+    'setuptools.lib2to3_ex',
+    'setuptools.msvc9_support',
+    'setuptools.package_index',
+    'setuptools.py26compat',
+    'setuptools.py27compat',
+    'setuptools.py31compat',
+    'setuptools.sandbox',
+    'setuptools.site-patch',
+    'setuptools.ssl_support',
+    'setuptools.unicode_utils',
+    'setuptools.utils',
+    'setuptools.version',
+    'setuptools.windows_support',
+    # 'pkg_resources',
+    # 'pkg_resources.extern',
     ]
 
     for m in setuptools_modules:
@@ -263,21 +272,21 @@ def fake_setuptools_modules():
     import distutils.core
     import distutils.util
     distutils_command_modules = [
-        'distutils.command.bdist'
-        'distutils.command.bdist_dumb',
-        'distutils.command.bdist_msi',
-        'distutils.command.bdist_rpm',
-        'distutils.command.bdist_wininst',
-        'distutils.command.build',
-        'distutils.command.build_clib',
-        'distutils.command.build_ext',
-        'distutils.command.build_py',
-        'distutils.command.build_scripts',
+    'distutils.command.bdist'
+    'distutils.command.bdist_dumb',
+    'distutils.command.bdist_msi',
+    'distutils.command.bdist_rpm',
+    'distutils.command.bdist_wininst',
+    'distutils.command.build',
+    'distutils.command.build_clib',
+    'distutils.command.build_ext',
+    'distutils.command.build_py',
+    'distutils.command.build_scripts',
     ]
     for m in distutils_command_modules:
         fake_module(m)
     sys.modules['distutils.util'].get_platform = OmniClass()
-    # fix for new problem in issue 169 
+    # fix for new problem in issue 169
     sys.modules['distutils.command.build_ext'].sub_commands = []
     sys.modules['setuptools.command.build_ext'].sub_commands = []
 
@@ -343,9 +352,9 @@ class CIConfigParer(SafeConfigParser):
         section_name = self._get_section_name(name)
         return SafeConfigParser.items(self, section_name)
 
-    def get(self, name, option_name):
+    def get(self, name, option_name, *args, **kwargs):
         section_name = self._get_section_name(name)
-        return SafeConfigParser.get(self, section_name, option_name)
+        return SafeConfigParser.get(self, section_name, option_name, *args, **kwargs)
 
     def set(self, name, option_name, value):
         section_name = self._get_section_name(name)
@@ -361,10 +370,12 @@ class PackageConfigHandler(object):
     Manager class for packages files for tracking installation of modules
     """
 
-    def __init__(self):
-        self.package_cfg = os.path.expanduser('~/Documents/site-packages/.pypi_packages')
+    def __init__(self, verbose=False):
+        self.verbose = verbose
+        self.package_cfg = os.path.join(SITE_PACKAGES_FOLDER, '.pypi_packages')
         if not os.path.isfile(self.package_cfg):
-            print('Creating package file')
+            if self.verbose:
+                print('Creating package file...')
             with open(self.package_cfg, 'w') as outs:
                 outs.close()
         self.parser = CIConfigParer()
@@ -440,8 +451,8 @@ class ArchiveFileInstaller(object):
     class SetupTransformer(ast.NodeTransformer):
         """
         Analyze and Transform AST of a setup file.
-            1. Create empty modules for any setuptools imports (if it is not already covered)
-            2. replace setup calls with a stub one to get values of its arguments
+        1. Create empty modules for any setuptools imports (if it is not already covered)
+        2. replace setup calls with a stub one to get values of its arguments
         """
 
         def visit_Import(self, node):
@@ -458,10 +469,10 @@ class ArchiveFileInstaller(object):
         def visit_Call(self, node):
             func_name = self._get_possible_setup_name(node)
             if func_name is not None and \
-                    (func_name == 'setup' or func_name.endswith('.setup')):
+            (func_name == 'setup' or func_name.endswith('.setup')):
                 node.func = ast.copy_location(
-                    ast.Name('_setup_stub_', ast.Load()),
-                    node.func)
+                ast.Name('_setup_stub_', ast.Load()),
+                node.func)
             return node
 
         def _get_possible_setup_name(self, node):
@@ -477,6 +488,10 @@ class ArchiveFileInstaller(object):
             else:
                 return None
 
+
+    def __init__(self, verbose=False):
+        self.verbose = verbose
+
     def run(self, pkg_name, archive_filename):
         """
         Main method for Installer to do its job.
@@ -490,32 +505,38 @@ class ArchiveFileInstaller(object):
 
             try:
                 print('Running setup file ...')
-                return ArchiveFileInstaller._run_setup_file(setup_filename)
+                return self._run_setup_file(setup_filename)
 
             except Exception as e:
                 print('{!r}'.format(e))
-                print('Failed to run setup.py\nFall back to directory guessing ...')
+                print('Failed to run setup.py')
+                if self.verbose:
+                    # print traceback
+                    print("")
+                    traceback.print_exc()
+                    print("")
+                print('Fall back to directory guessing ...')
 
                 pkg_name = pkg_name.lower().replace('-', '_')
 
                 if os.path.isdir(os.path.join(src_dir, pkg_name)):
                     ArchiveFileInstaller._safe_move(
-                        os.path.join(src_dir, pkg_name),
-                        os.path.join(SITE_PACKAGES_FOLDER, pkg_name)
+                    os.path.join(src_dir, pkg_name),
+                    os.path.join(SITE_PACKAGES_FOLDER, pkg_name)
                     )
                     return [os.path.join(SITE_PACKAGES_FOLDER, pkg_name)], []
 
                 elif os.path.isfile(os.path.join(src_dir, pkg_name + '.py')):
                     ArchiveFileInstaller._safe_move(
-                        os.path.join(src_dir, pkg_name + '.py'),
-                        os.path.join(SITE_PACKAGES_FOLDER, pkg_name + '.py')
+                    os.path.join(src_dir, pkg_name + '.py'),
+                    os.path.join(SITE_PACKAGES_FOLDER, pkg_name + '.py')
                     )
                     return [os.path.join(SITE_PACKAGES_FOLDER, pkg_name + '.py')], []
 
                 elif os.path.isdir(os.path.join(src_dir, 'src', pkg_name)):
                     ArchiveFileInstaller._safe_move(
-                        os.path.join(src_dir, 'src', pkg_name),
-                        os.path.join(SITE_PACKAGES_FOLDER, pkg_name)
+                    os.path.join(src_dir, 'src', pkg_name),
+                    os.path.join(SITE_PACKAGES_FOLDER, pkg_name)
                     )
                     return [os.path.join(SITE_PACKAGES_FOLDER, pkg_name)], []
 
@@ -542,12 +563,11 @@ class ArchiveFileInstaller(object):
 
         return EXTRACTED_FOLDER
 
-    @staticmethod
-    def _run_setup_file(filename):
+    def _run_setup_file(self, filename):
         """
         Transform and Run AST of the setup file
         """
-        
+
         try:
             import pkg_resources
         except ImportError:
@@ -555,11 +575,11 @@ class ArchiveFileInstaller(object):
             pkg_resources = None
 
         namespace = {
-            '_setup_stub_': _setup_stub_,
-            '__file__': filename,
-            '__name__': '__main__',
-            'setup_args': None,
-            'setup_kwargs': None,
+        '_setup_stub_': _setup_stub_,
+        '__file__': filename,
+        '__name__': '__main__',
+        'setup_args': None,
+        'setup_kwargs': None,
         }
 
         source_folder = os.path.dirname(filename)
@@ -574,7 +594,7 @@ class ArchiveFileInstaller(object):
         os.chdir(source_folder)
         sys.path.insert(0, source_folder)
         try:
-            exec (codeobj, namespace, namespace)
+            exec(codeobj, namespace, namespace)
         finally:
             os.chdir(saved_cwd)
             sys.path = saved_sys_path
@@ -601,7 +621,8 @@ class ArchiveFileInstaller(object):
         # while handling the packages
         scripts = kwargs.get("scripts", [])
         for script in scripts:
-            print("Handling commandline script: {s}".format(s=script))
+            if self.verbose:
+                print("Handling commandline script: {s}".format(s=script))
             cmdname = script.replace(os.path.dirname(script), "").replace("/", "")
             if not "." in cmdname:
                 cmdname += ".py"
@@ -619,8 +640,8 @@ class ArchiveFileInstaller(object):
                 for f in ArchiveFileInstaller._find_package_files(from_folder):
                     target_file = os.path.join(SITE_PACKAGES_FOLDER, f)
                     ArchiveFileInstaller._safe_move(
-                        os.path.join(from_folder, f),
-                        target_file
+                    os.path.join(from_folder, f),
+                    target_file
                     )
                     files_installed.append(target_file)
                     if use_2to3:
@@ -630,20 +651,20 @@ class ArchiveFileInstaller(object):
                 target_dir = os.path.join(SITE_PACKAGES_FOLDER, p)
                 if p in package_dirs:
                     ArchiveFileInstaller._safe_move(
-                        os.path.join(source_folder, package_dirs[p]),
-                        target_dir
+                    os.path.join(source_folder, package_dirs[p]),
+                    target_dir
                     )
 
                 elif '' in package_dirs:
                     ArchiveFileInstaller._safe_move(
-                        os.path.join(source_folder, package_dirs[''], p),
-                        target_dir
+                    os.path.join(source_folder, package_dirs[''], p),
+                    target_dir
                     )
 
                 else:
                     ArchiveFileInstaller._safe_move(
-                        os.path.join(source_folder, p),
-                        target_dir
+                    os.path.join(source_folder, p),
+                    target_dir
                     )
                 files_installed.append(target_dir)
                 if use_2to3:
@@ -658,8 +679,8 @@ class ArchiveFileInstaller(object):
             if os.path.isdir(os.path.join(source_folder, p)):  # folder
                 target_dir = os.path.join(SITE_PACKAGES_FOLDER, p)
                 ArchiveFileInstaller._safe_move(
-                    os.path.join(source_folder, p),
-                    target_dir
+                os.path.join(source_folder, p),
+                target_dir
                 )
                 files_installed.append(target_dir)
                 if use_2to3:
@@ -668,8 +689,8 @@ class ArchiveFileInstaller(object):
             else:  # file
                 target_file = os.path.join(SITE_PACKAGES_FOLDER, p + '.py')
                 ArchiveFileInstaller._safe_move(
-                    os.path.join(source_folder, p + '.py'),
-                    target_file
+                os.path.join(source_folder, p + '.py'),
+                target_file
                 )
                 files_installed.append(target_file)
                 if use_2to3:
@@ -684,6 +705,8 @@ class ArchiveFileInstaller(object):
                 print("Warning: pkg_resources not available, skipping entry_points definitions.")
                 entry_points = {}
         for epn in entry_points:
+            if self.verbose:
+                print("Handling entrypoints for: " + epn)
             ep = entry_points[epn]
             if isinstance(ep, (str, unicode)):
                 ep = [ep]
@@ -695,18 +718,18 @@ class ArchiveFileInstaller(object):
                         name += ".py"
                     desc = kwargs.get("description", "")
                     path = create_command(
-                        name,
-                        """'''{d}'''
-from {m} import {n}
+                    name,
+                    """'''{d}'''
+                    from {m} import {n}
 
-if __name__ == "__main__":
-    {n}()
-""".format(
-    m=modname,
-    n=funcname,
-    d=desc,
-    ),
-                        )
+                    if __name__ == "__main__":
+                    {n}()
+                    """.format(
+                    m=modname,
+                    n=funcname,
+                    d=desc,
+                    ),
+                    )
                     files_installed.append(path)
             else:
                 print("Warning: passing entry points for '{n}'.".format(n=epn))
@@ -763,8 +786,8 @@ if __name__ == "__main__":
         shutil.move(src, dest)
 
 
-package_config_handler = PackageConfigHandler()
-archive_file_installer = ArchiveFileInstaller()
+# package_config_handler = PackageConfigHandler()
+# archive_file_installer = ArchiveFileInstaller()
 
 
 class PackageRepository(object):
@@ -774,9 +797,10 @@ class PackageRepository(object):
     This is a base class providing basic layout of a Repository.
     """
 
-    def __init__(self):
-        self.config = package_config_handler
-        self.installer = archive_file_installer
+    def __init__(self, verbose=False):
+        self.verbose = verbose
+        self.config = PackageConfigHandler(verbose=self.verbose)
+        self.installer = ArchiveFileInstaller(verbose=self.verbose)
 
     def versions(self, pkg_name):
         raise PipError('versions only available for PyPI packages')
@@ -793,7 +817,7 @@ class PackageRepository(object):
         # never install setuptools as dependency
         dependencies = [dependency for dependency in dependencies if dependency != 'setuptools']
         name_versions = [VersionSpecifier.parse_requirement(requirement)
-                         for requirement in dependencies]
+        for requirement in dependencies]
         sys.modules['setuptools']._installed_requirements_.append(pkg_name)
         pkg_info['files'] = ','.join(files_installed)
         pkg_info['dependency'] = ','.join(name_version[0] for name_version in name_versions)
@@ -863,7 +887,7 @@ class PackageRepository(object):
                         # that do not have a dependency option (since they are manually
                         # installed before).
                         if self.config.module_exists(dependency) \
-                                and self.config.get_dependencies(dependency) is not None:
+                        and self.config.get_dependencies(dependency) is not None:
                             print('Removing dependency: {}'.format(dependency))
                             self.remove(dependency)
 
@@ -882,9 +906,13 @@ class PyPIRepository(PackageRepository):
     This repository performs its actions using the PyPI as a backend store.
     """
 
-    def __init__(self):
-        super(PyPIRepository, self).__init__()
-        import xmlrpclib
+    def __init__(self, *args, **kwargs):
+        super(PyPIRepository, self).__init__(*args, **kwargs)
+        try:
+            import xmlrpclib
+        except ImportError:
+            # py3
+            import xmlrpc.client as xmlrpclib
         # DO NOT USE self.pypi, it's there just for search, it's obsolete/legacy
         self.pypi = xmlrpclib.ServerProxy('https://pypi.python.org/pypi')
         self.standard_package_names = {}
@@ -930,7 +958,7 @@ class PyPIRepository(PackageRepository):
     def _package_info(self, pkg_data):
         return pkg_data['info']
 
-    def versions(self, pkg_name):                
+    def versions(self, pkg_name):
         pkg_name = self.get_standard_package_name(pkg_name)
         pkg_data = self._package_data(pkg_name)
         releases = self._package_releases(pkg_data)
@@ -1026,7 +1054,7 @@ class GitHubRepository(PackageRepository):
     def versions(self, owner_repo):
         owner, repo = owner_repo.split('/')
         data = requests.get('https://api.github.com/repos/{}/{}/releases'.format(
-            owner, repo
+        owner, repo
         )).json()
         return [entry['name'] for entry in data]
 
@@ -1035,17 +1063,17 @@ class GitHubRepository(PackageRepository):
 
         owner, repo = owner_repo.split('/')
         metadata = requests.get('https://api.github.com/repos/{}/{}'.format(
-            owner, repo
+        owner, repo
         )).json()
 
         _stash('wget https://github.com/{0}/{1}/archive/{2}.zip -o $TMPDIR/{2}.zip'.format(
-            owner, repo, release
+        owner, repo, release
         ))
         return os.path.join(os.getenv('TMPDIR'), release + '.zip'), {
-            'name': owner_repo,
-            'url': 'github',
-            'version': release,
-            'summary': metadata.get('description', ''),
+        'name': owner_repo,
+        'url': 'github',
+        'version': release,
+        'summary': metadata.get('description', ''),
         }
 
     def install(self, owner_repo, ver_spec):
@@ -1070,10 +1098,10 @@ class UrlRepository(PackageRepository):
         _stash('wget {} -o $TMPDIR/{}'.format(url, archive_filename))
 
         return os.path.join(os.getenv('TMPDIR'), archive_filename), {
-            'name': url,
-            'url': 'url',
-            'version': '',
-            'summary': '',
+        'name': url,
+        'url': 'url',
+        'version': '',
+        'summary': '',
         }
 
     def install(self, url, ver_spec):
@@ -1092,48 +1120,50 @@ class LocalRepository(PackageRepository):
 
     def install(self, archive_filename, ver_spec):
         pkg_info = {
-            'name': archive_filename,
-            'url': 'local',
-            'version': '',
-            'summary': ''
+        'name': archive_filename,
+        'url': 'local',
+        'version': '',
+        'summary': ''
         }
         self._install(pkg_name, pkg_info, archive_filename)
 
 
-url_repository = UrlRepository()
-local_repository = LocalRepository()
-github_repository = GitHubRepository()
-pypi_repository = PyPIRepository()
+# url_repository = UrlRepository()
+# local_repository = LocalRepository()
+# github_repository = GitHubRepository()
+# pypi_repository = PyPIRepository()
 
 
-def get_repository(pkg_name):
+def get_repository(pkg_name, verbose=False):
     """
     The corresponding repository based on the given package name.
     :param pkg_name: It can be one of the four following options:
-                        1. An URL pointing to an archive file
-                        2. Path to a local archive file
-                        3. A owner/repo pair pointing to a GitHub repo
-                        4. A name representing a PyPI package.
+    1. An URL pointing to an archive file
+    2. Path to a local archive file
+    3. A owner/repo pair pointing to a GitHub repo
+    4. A name representing a PyPI package.
+    :param verbose: enable additional output
+    :type verbose: bool
     """
 
     if pkg_name.startswith('http://') \
-            or pkg_name.startswith('https://') \
-            or pkg_name.startswith('ftp://'):  # remote archive file
+    or pkg_name.startswith('https://') \
+    or pkg_name.startswith('ftp://'):  # remote archive file
         print('Working on URL repository ...')
-        return url_repository
+        return UrlRepository(verbose=verbose)
 
     # local archive file
     elif os.path.isfile(pkg_name) and \
-            (pkg_name.endswith('.zip') or pkg_name.endswith('.gz') or pkg_name.endswith('.bz2')):
+    (pkg_name.endswith('.zip') or pkg_name.endswith('.gz') or pkg_name.endswith('.bz2')):
         print('Working on Local repository ...')
-        return local_repository
+        return LocalRepository(verbose=verbose)
 
     elif '/' in pkg_name:  # github, e.g. selectel/pyte
         print('Working on GitHub repository ...')
-        return GitHubRepository()
+        return GitHubRepository(verbose=verbose)
 
     else:  # PyPI
-        return PyPIRepository()
+        return PyPIRepository(verbose=verbose)
 
 
 class VersionSpecifier(object):
@@ -1141,12 +1171,12 @@ class VersionSpecifier(object):
     This class is to represent the versions of a requirement, e.g. pyte==0.4.10.
     """
     OPS = {'<=': operator.le,
-           '<': operator.lt,
-           '!=': operator.ne,
-           '>=': operator.ge,
-           '>': operator.gt,
-           '==': operator.eq,
-           '~=': operator.ge}
+    '<': operator.lt,
+    '!=': operator.ne,
+    '>=': operator.ge,
+    '>': operator.gt,
+    '==': operator.eq,
+    '~=': operator.ge}
 
     def __init__(self, version_specs):
         self.specs = [(VersionSpecifier.OPS[op], version) for (op, version) in version_specs]
@@ -1188,25 +1218,25 @@ if __name__ == '__main__':
     ap.add_argument('--verbose', action='store_true', help='be more chatty')
 
     subparsers = ap.add_subparsers(dest='sub_command',
-                                   title='List of sub-commands',
-                                   metavar='sub-command',
-                                   help='"pip sub-command -h" for more help on a sub-command')
+    title='List of sub-commands',
+    metavar='sub-command',
+    help='"pip sub-command -h" for more help on a sub-command')
 
     list_parser = subparsers.add_parser('list', help='list packages installed')
 
     install_parser = subparsers.add_parser('install', help='install a package')
     install_parser.add_argument('requirement',
-                                help='the requirement specifier for installation')
+    help='the requirement specifier for installation')
     install_parser.add_argument('-N', '--no-overwrite', action='store_true', default=False,
-                                help='Do not overwrite existing folder/files')
+    help='Do not overwrite existing folder/files')
     install_parser.add_argument('-d', '--directory',
-                                help='target directory for installation')
+    help='target directory for installation')
 
     download_parser = subparsers.add_parser('download', help='download a package')
     download_parser.add_argument('requirement',
-                                 help='the requirement specifier for download')
+    help='the requirement specifier for download')
     download_parser.add_argument('-d', '--directory',
-                                 help='the directory to save the downloaded file')
+    help='the directory to save the downloaded file')
 
     search_parser = subparsers.add_parser('search', help='search with the given word fragment')
     search_parser.add_argument('term', help='the word fragment to search')
@@ -1224,13 +1254,13 @@ if __name__ == '__main__':
 
     try:
         if ns.sub_command == 'list':
-            repository = get_repository('pypi')
+            repository = get_repository('pypi', verbose=ns.verbose)
             info_list = repository.list()
             for module, info in info_list:
                 print('{} ({}) - {}'.format(module, info['version'], info['summary']))
 
         elif ns.sub_command == 'install':
-            repository = get_repository(ns.requirement)
+            repository = get_repository(ns.requirement, verbose=ns.verbose)
             if ns.directory is not None:
                 SITE_PACKAGES_FOLDER = ns.directory
             NO_OVERWRITE = ns.no_overwrite
@@ -1245,32 +1275,32 @@ if __name__ == '__main__':
                 repository.install(pkg_name, ver_spec)
 
         elif ns.sub_command == 'download':
-            repository = get_repository(ns.requirement)
+            repository = get_repository(ns.requirement, verbose=ns.verbose)
             pkg_name, ver_spec = VersionSpecifier.parse_requirement(ns.requirement)
             archive_filename, pkg_info = repository.download(pkg_name, ver_spec)
             directory = ns.directory or os.getcwd()
             shutil.move(archive_filename, directory)
 
         elif ns.sub_command == 'search':
-            repository = get_repository('pypi')
+            repository = get_repository('pypi', verbose=ns.verbose)
             search_hits = repository.search(ns.term)
             search_hits = sorted(search_hits, key=lambda pkg: pkg['_pypi_ordering'], reverse=True)
             for hit in search_hits:
                 print('{} {} - {}'.format(hit['name'], hit['version'], hit['summary']))
 
         elif ns.sub_command == 'versions':
-            repository = get_repository(ns.package_name)
+            repository = get_repository(ns.package_name, verbose=ns.verbose)
             version_hits = repository.versions(ns.package_name)
             for hit in version_hits:
                 print('{} - {}'.format(ns.package_name, hit))
 
         elif ns.sub_command == 'remove':
-            repository = get_repository('pypi')
+            repository = get_repository('pypi', verbose=ns.verbose)
             repository.remove(ns.package_name)
 
         elif ns.sub_command == 'update':
-            repository = get_repository(ns.package_name)
-            
+            repository = get_repository(ns.package_name, verbose=ns.verbose)
+
             with save_current_sys_modules():
                 fake_setuptools_modules()
                 ensure_pkg_resources()  # install pkg_resources if needed

--- a/bin/python3.py
+++ b/bin/python3.py
@@ -60,7 +60,7 @@ if passing_h:
 if ns.module:
     sys.argv = [ns.module] + ns.args_to_pass
     try:
-        runpy.run_module(str(ns.module), run_name='__main__')
+        runpy.run_module(ns.module, run_name='__main__')
     except ImportError as e:
         print('ImportError: ' + str(e))
         sys.exit(1)
@@ -83,7 +83,7 @@ else:
             '__doc__': None,
             '__package__': None,
             '__debug__': True,
-            '__builtins__': builtins,  # yes, __builtins__
+            '__builtins__': builtins,
             '_stash': _stash,
         }
         code.interact(local=locals)

--- a/bin/python3.py
+++ b/bin/python3.py
@@ -1,22 +1,22 @@
 """
-Simulates a console call to python [-m module][-c cmd] [file] [args]
+Simulates a console call to python3 [-m module][-c cmd] [file] [args]
 
-Used for running standard library python modules such as:
-SimpleHTTPServer, unittest and .py files.
+Used for running standard library python3 modules such as:
+unittest and .py files.
 
 Can also be used to run a script in the background, such as a server, with the bash character & at the end.
 usage:
-    python
-    python -m module_name [args]
-    python -c command
-    python python_file.py [args]
+    python3
+    python3 -m module_name [args]
+    python3 -c command
+    python3 python_file.py [args]
 """
 # check for py2/3
 _stash = globals()["_stash"]
-if _stash.PY3:
+if not _stash.PY3:
 	print(
 		_stash.text_color(
-			"You are running StaSh in python3.\nRunning python 2 from python 3 is not (yet) supported.\nPlease use the 'python3' command instead.",
+			"You are running StaSh in python 2.\nRunning python3 from python 2 is not (yet) supported.\nPlease use the 'python' command instead.",
 			"red",
 			)
 		)
@@ -27,7 +27,7 @@ import runpy
 import sys
 import argparse
 import code
-import __builtin__
+import builtins
 
 
 args = sys.argv[1:]
@@ -83,7 +83,7 @@ else:
             '__doc__': None,
             '__package__': None,
             '__debug__': True,
-            '__builtins__': __builtin__,  # yes, __builtins__
+            '__builtins__': builtins,  # yes, __builtins__
             '_stash': _stash,
         }
         code.interact(local=locals)

--- a/bin/rm.py
+++ b/bin/rm.py
@@ -45,7 +45,7 @@ def main(args):
     #setup print function
     if ns.verbose:
         def printp(text):
-            print text
+            print(text)
     else:
         def printp(text):
             pass
@@ -69,7 +69,7 @@ def main(args):
                     printp('%s has been deleted' % path)
                 except:
                     if not ns.force:
-                        print '%s: unable to remove' % path
+                        print('%s: unable to remove' % path)
 
         elif os.path.isdir(path) and ns.recursive:
             if prompt(path):
@@ -78,13 +78,13 @@ def main(args):
                     printp('%s has been deleted' % path)
                 except:
                     if not ns.force:
-                        print '%s: unable to remove' % path
+                        print('%s: unable to remove' % path)
 
         elif os.path.isdir(path):
-            print '%s: is a directory' % path
+            print('%s: is a directory' % path)
         else:
             if not ns.force:
-                print '%s: does not exist' % path
+                print('%s: does not exist' % path)
 
 
 if __name__ == '__main__':

--- a/bin/selfupdate.py
+++ b/bin/selfupdate.py
@@ -21,7 +21,8 @@ URL_BASE = 'https://raw.githubusercontent.com/{owner}/stash'
 
 
 class UpdateError(Exception):
-    pass
+    def __init__(self, message=""):
+    	self.message = message
 
 
 def get_remote_version(owner, branch):
@@ -32,7 +33,7 @@ def get_remote_version(owner, branch):
     """
     import ast
 
-    url = '%s/%s/stash.py?q=%s' % (URL_BASE.format(owner=owner), branch, randint(1, 999999))
+    url = '%s/%s/core.py?q=%s' % (URL_BASE.format(owner=owner), branch, randint(1, 999999))
 
     try:
         req = requests.get(url)
@@ -108,9 +109,12 @@ def main(args):
                            _stash.text_style(url, {'color': 'blue', 'traits': ['underline']})))
 
         try:
-            exec requests.get(
+            exec(
+            	requests.get(
                 '{}?q={}'.format(url, randint(1, 999999))
-            ).text in {'_IS_UPDATE': True, '_br': branch, '_owner': owner}
+                ).text,
+                {'_IS_UPDATE': True, '_br': branch, '_owner': owner},
+                )
             print(_stash.text_color('Update completed.', 'green'))
             print(_stash.text_color(
                 'Please restart Pythonista to ensure changes becoming effective.', 'green'))

--- a/bin/stashconf.py
+++ b/bin/stashconf.py
@@ -22,19 +22,19 @@ def main(args):
 
     if ns.list:
         for name in sorted(config.keys()):
-            print '%s=%s' % (name, config[name].__dict__[name])
+            print('%s=%s' % (name, config[name].__dict__[name]))
 
     else:
         try:
             if ns.name is not None and ns.value is not None:
                 config[ns.name].__dict__[ns.name] = ns.value
             elif ns.name is not None:
-                print '%s=%s' % (ns.name, config[ns.name].__dict__[ns.name])
+                print('%s=%s' % (ns.name, config[ns.name].__dict__[ns.name]))
             else:
                 ap.print_help()
 
         except KeyError:
-            print '%s: invalid config option name' % ns.name
+            print('%s: invalid config option name' % ns.name)
             sys.exit(1)
 
 

--- a/bin/tar.py
+++ b/bin/tar.py
@@ -36,7 +36,7 @@ import tarfile
 
 def output_print(msg):
     if args.verbose:
-        print msg
+        print(msg)
         
 class MyFileObject(tarfile.ExFileObject):
     def read(self, size, *args):
@@ -70,7 +70,7 @@ def extract_all(filename,members=None, directory=''):
     else:
         tar.extractall(path=directory)
     tar.close()
-    print 'Archive extracted.'
+    print('Archive extracted.')
     
     
 def create_tar(filename,files):
@@ -93,7 +93,7 @@ def create_tar(filename,files):
         output_print('Adding %s' % name)
         tar.add(name, filter=tar_filter)
     tar.close()
-    print 'Archive Created.' 
+    print('Archive Created.' )
     
 def list_tar(filename):
     if args.gzip:
@@ -132,4 +132,3 @@ if __name__=='__main__':
         create_tar(os.path.expanduser(args.file),args.files)
     elif args.extract:
         extract_all(os.path.expanduser(args.file),args.files, directory=args.directory)
-

--- a/bin/totd.py
+++ b/bin/totd.py
@@ -24,11 +24,11 @@ def main(args):
         tips = json.load(ins)
 
         if ns.count:
-            print 'Total available tips: %s' % len(tips)
+            print('Total available tips: %s' % len(tips))
         else:
             idx = random.randint(0, len(tips) - 1)
-            print '%s: %s' % (_stash.text_bold('Tip'),
-                              _stash.text_italic(tips[idx]))
+            print('%s: %s' % (_stash.text_bold('Tip'),
+                              _stash.text_italic(tips[idx])))
 
 
 if __name__ == '__main__':

--- a/bin/unzip.py
+++ b/bin/unzip.py
@@ -19,18 +19,18 @@ def main(args):
     ns = ap.parse_args(args)
 
     if not os.path.isfile(ns.zipfile):
-        print "%s: No such file" % ns.zipfile
+        print("%s: No such file" % ns.zipfile)
 
     else:
         # PK magic marker check
-        with open(ns.zipfile) as f:
+        with open(ns.zipfile, "rb") as f:
             try:
                 pk_check = f.read(2)
             except:
                 pk_check = ''
 
-        if pk_check != 'PK':
-            print "%s: does not appear to be a zip file" % ns.zipfile
+        if pk_check != b'PK':
+            print("%s: does not appear to be a zip file" % ns.zipfile)
             sys.exit(1)
 
         if ns.list:
@@ -43,7 +43,7 @@ def main(args):
             altpath = os.path.join(os.path.dirname(ns.zipfile), altpath)
             location = ns.exdir or altpath
             if (os.path.exists(location)) and not (os.path.isdir(location)):
-                print "%s: destination is not a directory" % location
+                print("%s: destination is not a directory" % location)
                 sys.exit(1)
             elif not os.path.exists(location):
                 os.makedirs(location)
@@ -84,9 +84,9 @@ def main(args):
                             fp.close()
 
                     if ns.verbose or ns.list:
-                        print fn
+                        print(fn)
             except:
-                print "%s: zip file is corrupt" % ns.zipfile
+                print("%s: zip file is corrupt" % ns.zipfile)
 
 
 if __name__ == '__main__':

--- a/bin/version.py
+++ b/bin/version.py
@@ -10,6 +10,7 @@ import plistlib
 _stash = globals()['_stash']
 collapseuser = _stash.libcore.collapseuser
 
+
 # Following functions for getting Pythonista and iOS version information are adapted from
 # https://github.com/cclauss/Ten-lines-or-less/blob/master/pythonista_version.py
 def pythonista_version():  # 2.0.1 (201000)
@@ -25,21 +26,22 @@ def ios_version():  # 9.2 (64-bit iPad5,4)
 
 def main():
     STASH_ROOT = os.environ['STASH_ROOT']
-    print _stash.text_style('StaSh v%s' % globals()['_stash'].__version__,
-                            {'color': 'blue', 'traits': ['bold']})
-    print u'%s %s' % (_stash.text_bold('Pythonista'),
-                      pythonista_version())
-    print u'%s %s' % (_stash.text_bold('iOS'),
-                      ios_version())
-    print u'%s: %s' % (_stash.text_bold('root'), collapseuser(STASH_ROOT))
-    _stat = os.stat(os.path.join(STASH_ROOT, 'stash.py'))
+    print(_stash.text_style('StaSh v%s' % globals()['_stash'].__version__,
+                            {'color': 'blue', 'traits': ['bold']}))
+    print(u'%s %s' % (_stash.text_bold('Pythonista'),
+                      pythonista_version()))
+    print(u'%s %s' % (_stash.text_bold('iOS'),
+                      ios_version()))
+    print(u'%s %s' % (_stash.text_bold('Python'), os.environ['STASH_PY_VERSION']))
+    print(u'%s: %s' % (_stash.text_bold('root'), collapseuser(STASH_ROOT)))
+    _stat = os.stat(os.path.join(STASH_ROOT, 'core.py'))
     last_modified = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(_stat.st_mtime))
-    print u'%s: %s' % (_stash.text_bold('stash.py'), last_modified)
-    print u'%s: %s' % (_stash.text_bold('SELFUPDATE_BRANCH'),
-                       os.environ['SELFUPDATE_BRANCH'])
-    print _stash.text_bold('BIN_PATH:')
+    print(u'%s: %s' % (_stash.text_bold('core.py'), last_modified))
+    print(u'%s: %s' % (_stash.text_bold('SELFUPDATE_BRANCH'),
+                       os.environ['SELFUPDATE_BRANCH']))
+    print(_stash.text_bold('BIN_PATH:'))
     for p in os.environ['BIN_PATH'].split(':'):
-        print '  %s' % collapseuser(p)
+        print('  %s' % collapseuser(p))
 
 
 if __name__ == '__main__':

--- a/bin/wget.py
+++ b/bin/wget.py
@@ -2,8 +2,13 @@
 """
 
 import sys
-import urllib2
 import argparse
+
+try:
+	import urllib2
+except ImportError:
+	# py3
+	import urllib.request as urllib2
 
 try:
     import clipboard
@@ -24,17 +29,20 @@ def main(args):
     console.show_activity()
     try:
 
-        print 'Opening: %s' % url
+        sys.stdout.write('Opening: %s\n' % url)
         u = urllib2.urlopen(url)
 
         meta = u.info()
         try:
-            file_size = int(meta.getheaders("Content-Length")[0])
-        except IndexError:
+            if _stash.PY3:
+                file_size = int(meta["Content-Length"])
+            else:
+                file_size = int(meta.getheaders("Content-Length")[0])
+        except (IndexError, ValueError, TypeError):
             file_size = 0
 
-        print "Save as: %s " % output_file,
-        print "(%s bytes)" % file_size if file_size else ""
+        sys.stdout.write("Save as: {} ".format(output_file))
+        sys.stdout.write("({} bytes)\n".format(file_size if file_size else "???"))
 
         with open(output_file, 'wb') as f:
             file_size_dl = 0
@@ -49,11 +57,12 @@ def main(args):
                     status = r"%10d  [%3.2f%%]" % (file_size_dl, file_size_dl * 100. / file_size)
                 else:
                     status = "%10d" % file_size_dl
-                print '\r' + status,
-            print
+                sys.stdout.write('\r' + status)
+            sys.stdout.write("\n")
 
-    except:
-        print 'invalid url: %s' % url
+    except Exception as e:
+        raise e
+        sys.stdout.write('invalid url: %s\n' % url)
         sys.exit(1)
 
     finally:

--- a/bin/zip.py
+++ b/bin/zip.py
@@ -20,7 +20,7 @@ def main(args):
         for path in ns.list:
             if os.path.isfile(path):
                 if ns.verbose:
-                    print path
+                    print(path)
                 arcname = os.path.relpath(path, relroot)
                 outs.write(path, arcname=arcname)
 
@@ -30,16 +30,15 @@ def main(args):
                     # add directory (needed for empty dirs)
                     outs.write(root, arcname=this_relroot)
                     if ns.verbose:
-                        print this_relroot
+                        print(this_relroot)
                     for f in files:
                         filename = os.path.join(root, f)
                         if os.path.isfile(filename):  # regular files only
                             if ns.verbose:
-                                print filename
+                                print(filename)
                             arcname = os.path.join(this_relroot, f)
                             outs.write(filename, arcname=arcname)
 
 
 if __name__ == '__main__':
     main(sys.argv[1:])
-

--- a/core.py
+++ b/core.py
@@ -152,7 +152,7 @@ class StaSh(object):
         self.runtime.load_rcfile(no_rcfile=no_rcfile)
         self.io.write(
         	self.text_style(
-        		'StaSh v%s on python %s' % (
+        		'StaSh v%s on python %s\n' % (
         			self.__version__,
         			platform.python_version(),
         			), 

--- a/core.py
+++ b/core.py
@@ -9,6 +9,7 @@ __version__ = '0.6.20'
 
 import os
 import sys
+import platform
 
 try:
 	# try to import py2 modules
@@ -149,9 +150,16 @@ class StaSh(object):
         if IN_PYTHONISTA:
             os.chdir(self.runtime.state.environ_get('HOME2'))
         self.runtime.load_rcfile(no_rcfile=no_rcfile)
-        self.io.write(self.text_style('StaSh v%s\n' % self.__version__,
-                                      {'color': 'blue', 'traits': ['bold']},
-                                      always=True))
+        self.io.write(
+        	self.text_style(
+        		'StaSh v%s on python %s' % (
+        			self.__version__,
+        			platform.python_version(),
+        			), 
+        		{'color': 'blue', 'traits': ['bold']},
+        		always=True,
+        		),
+        	)
         # Load shared libraries
         self._load_lib()
 

--- a/core.py
+++ b/core.py
@@ -63,7 +63,7 @@ _DEBUG_COMPLETER = 403
 # Default configuration (can be overridden by external configuration file)
 _DEFAULT_CONFIG = """[system]
 rcfile=.stashrc
-py_traceback=1
+py_traceback=0
 py_pdb=0
 input_encoding_utf8=1
 ipython_style_history_search=1

--- a/docs/py3_todo.md
+++ b/docs/py3_todo.md
@@ -2,7 +2,7 @@
 List of known issues, bugs and todos for stash py3 (and py2) compatibility.
 
 #General
-- 'cc'-key crashes pythonista
+- ctype threads in py3 bugged (crash on cc and kill)
 - more commands need to be ported
 - sys.argv needs to be bytestr in py2 and unistt in py3. There is only a quick fix in place (somewhere in `shruntime.py`), which should be replaced as it only works for common usage situations
 - unittests for py3

--- a/docs/py3_todo.md
+++ b/docs/py3_todo.md
@@ -1,0 +1,25 @@
+#Python 3 TODO
+List of known issues, bugs and todos for stash py3 (and py2) compatibility.
+
+#General
+- 'cc'-key crashes pythonista
+- more commands need to be ported
+- sys.argv needs to be bytestr in py2 and unistt in py3. There is only a quick fix in place (somewhere in `shruntime.py`), which should be replaced as it only works for common usage situations
+- unittests for py3
+- i/o seems to switch between jobs from time to time
+
+
+#`clear.py`
+- prevent linebreak after screen clearing. This was removed and needs to be readded.
+
+#`crypt.py`
+- in py3, the key is shown as `b'<key>'` instead of `<key>`. Also test solution with py2
+
+#`curl.py`
+- more testing
+
+#`easy_config.py`
+- while syntax is py3 compatible, there are some errors
+
+#Non py3-issues
+- `cp.py` has no `-r` argument

--- a/docs/py3_todo.md
+++ b/docs/py3_todo.md
@@ -20,6 +20,12 @@ List of known issues, bugs and todos for stash py3 (and py2) compatibility.
 
 #`easy_config.py`
 - while syntax is py3 compatible, there are some errors
+- untested
+
+#`pip.py`
+- many bugs
+- installation using `setupy.py` fails most of the time, always falls back to package detection
+- maybe `pip3` for py3 instead of a single `pip` command.
 
 #Non py3-issues
 - `cp.py` has no `-r` argument

--- a/launch_stash.py
+++ b/launch_stash.py
@@ -1,4 +1,3 @@
-#!python2
 # coding: utf-8
 """
 Launch StaSh in a more flexible and reliable way.

--- a/lib/libcore.py
+++ b/lib/libcore.py
@@ -1,6 +1,13 @@
 import os
 import fileinput
 
+from stash.system.shcommon import PY3
+
+
+if PY3:
+	# py3 compatibility
+	unicode = str
+
 
 def collapseuser(path):
     """Reverse of os.path.expanduser: return path relative to ~, if

--- a/system/shcommon.py
+++ b/system/shcommon.py
@@ -51,6 +51,7 @@ _STASH_ROOT = os.path.realpath(os.path.abspath(
     os.path.dirname(os.path.dirname(__file__))))
 _STASH_CONFIG_FILES = ('.stash_config', 'stash.cfg')
 _STASH_HISTORY_FILE = '.stash_history'
+
 # directory for stash extensions
 _STASH_EXTENSION_PATH = os.path.abspath(
 	os.path.join(os.getenv("HOME"), "Documents", "stash_extensions"),
@@ -71,6 +72,9 @@ _EXTERNAL_DIRS = [
 	_STASH_EXTENSION_FSI_PATH,
 	_STASH_EXTENSION_PATCH_PATH,
 	]
+
+# py3 or not py3
+PY3 = (sys.version_info >= (3, 0))
 
 # Save the true IOs
 if IN_PYTHONISTA:

--- a/system/shcommon.py
+++ b/system/shcommon.py
@@ -201,11 +201,13 @@ def sh_background(name=None):
 
 
 class ShFileNotFound(Exception):
-    pass
+    def __init__(self, message=""):
+    	self.message = message
 
 
 class ShIsDirectory(Exception):
-    pass
+    def __init__(self, message=""):
+    	self.message = message
 
 
 class ShNotExecutable(Exception):

--- a/system/shparsers.py
+++ b/system/shparsers.py
@@ -5,7 +5,11 @@ import string
 import glob
 import logging
 import threading
-from StringIO import StringIO
+try:
+	from StringIO import StringIO
+except ImportError:
+	# py3
+	from io import StringIO
 
 import pyparsing as pp
 

--- a/system/shscreens.py
+++ b/system/shscreens.py
@@ -15,9 +15,14 @@ try:
 except ImportError:
     from dummyobjc_util import *
 
-from .shcommon import IN_PYTHONISTA, ON_IOS_8
+from .shcommon import IN_PYTHONISTA, ON_IOS_8, PY3
 # noinspection PyPep8Naming
 from .shcommon import sh_delay, Graphics as graphics
+
+
+if PY3:
+	# set xrange as alias for range
+	xrange = range
 
 NSMutableAttributedString = ObjCClass('NSMutableAttributedString')
 UIFont = ObjCClass('UIFont')

--- a/system/shstreams.py
+++ b/system/shstreams.py
@@ -9,7 +9,13 @@ import logging
 import re
 
 # noinspection PyPep8Naming
-from .shcommon import Control as ctrl, Escape as esc
+from .shcommon import Control as ctrl, Escape as esc, PY3
+
+
+if PY3:
+	# rename str, unicode and bytes
+	unicode = str
+	str = bytes
 
 
 class ShMiniBuffer(object):

--- a/system/shterminal.py
+++ b/system/shterminal.py
@@ -12,7 +12,13 @@ except ImportError:
     import dummyui as ui
     from .dummyobjc_util import *
 
-from .shcommon import CTRL_KEY_FLAG
+from .shcommon import CTRL_KEY_FLAG, PY3
+
+
+if PY3:
+	# rename string types
+	unicode = str
+	str = bytes
 
 # ObjC related stuff
 UIFont = ObjCClass('UIFont')


### PR DESCRIPTION
Hi,
this pull request attempts to make StaSh both py2 and py3 compatible.
It still contains some bugs and many commands are still incompatible with py3, however i dont think a single person can update stash to py3 alone (e.g. i am unable to port `git` or fix `ctype` threads).
I hope this PR can provide a solid base for completely making StaSh py3 compatible.

**Status:**
- stash core works in general (with some bugs) in both py2 and py3
- some base commands (`ls`, `cp`, ...) ported
- no *big* commands ported (`git`, `gh`, `mount`, ...)
- nearly full compatibility with py2

**Important information**:
- I hade to rename `stash.py` to `core.py` due to import issues, but if you want i can try to rename it back (also needs changes to `selfupdate.py`, ... )
- due to the change above, the old `selfupdate` can no longer check the version of the new stash version and an update needs to be forced using `selfupdate -f`.

**Known bugs**:
- `ctype` are bugged; they crash pythonista when killed
- `clear` does print a newline
- encoding of `sys.argv` for commands needs to be improved; currently there is only a quick fix in `shruntime.py`, which encodes sys.argv with `utf-8`. 

**pip changes:**
- actually print more informations (like traceback) if `--verbose` was specified.
- in py2, install packages to `site-packages-2`; in py3 to `site-packages-3` instead. Maybe we should add an argument to use  `site-packages` instead?

**Other changes:**
- add `python3` command
- add a `STASH_PY_VERSION` environment variable, which is also printed by `version.py`.
- minor changes

For more information, please see `$STASH_ROOT/docs/py3_todo.py`