### PR TITLE
Start testing on Python 3 in allow_failures mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,19 @@
 language: python
 python:
   - "2.7"
+  - "3.6"
+matrix:
+  allow_failures:
+    - python: "3.6"
 # command to install dependencies
 install:
   - "pip install pyparsing==2.0.1"
+  - "pip install pytest>=3.5.0"
+  - "pip install flake8>=3.5.0"
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 # command to run tests
-script: python testing.py -v
+script: py.test system/tests --ignore=system/tests/data

--- a/bin/clear.py
+++ b/bin/clear.py
@@ -1,2 +1,3 @@
 """Clear the stash console output window"""
+_stash = globals()['_stash']
 _stash.term.truncate(size=0)

--- a/bin/cp.py
+++ b/bin/cp.py
@@ -7,6 +7,8 @@ from __future__ import print_function
 import argparse
 import os
 import shutil
+import sys
+
 
 def pprint(path):
     if path.startswith(os.environ['HOME']):

--- a/bin/crypt.py
+++ b/bin/crypt.py
@@ -13,12 +13,13 @@ optional arguments:
   -k KEY, --key KEY  Encrypt/Decrypt Key.
   -d, --decrypt      Flag to decrypt.
 '''
-import sys
 import os
+import sys
 try:
     from simplecrypto.key import AesKey
-except:
-    print 'Installing Required packages.'
+except Exception:
+    print('Installing Required packages.')
+    _stash = globals()['_stash']
     _stash('pip install simplecrypto')
     sys.exit(0)
 
@@ -45,6 +46,7 @@ class Crypt(object):
 
             
 if __name__=='__main__':
+    import argparse
     ap = argparse.ArgumentParser()
     ap.add_argument('-k','--key',action='store',default='',help='Encrypt/Decrypt Key.')
     ap.add_argument('-d','--decrypt',action='store_true',default=False,help='Flag to decrypt.')
@@ -57,4 +59,3 @@ if __name__=='__main__':
         crypt.aes_decrypt(args.key)
     else:
         crypt.aes_encrypt(args.key)
-

--- a/bin/git.py
+++ b/bin/git.py
@@ -22,12 +22,17 @@ commands:
     help: git help
 '''
 
-SAVE_PASSWORDS = True
-
 import argparse
-import getpass
-import urlparse,urllib2,keychain
-import sys,os
+import os
+import sys
+import urllib2
+import urlparse
+
+import console
+import keychain
+
+_stash = globals()['_stash']
+SAVE_PASSWORDS = True
 
 # temporary -- install required modules
 
@@ -80,7 +85,6 @@ else:
 #  end temporary
 
 
-
 command_help={    'init':  'initialize a new Git repository'
     ,'add': 'stage one or more files'
     ,'rm': 'git rm <file1> .. [file2] .. - unstage one or more files'
@@ -99,7 +103,6 @@ command_help={    'init':  'initialize a new Git repository'
           }
 
 
-    
     #Find a git repo dir
 def _find_repo(path):
     subdirs = os.walk(path).next()[1]

--- a/bin/mail.py
+++ b/bin/mail.py
@@ -18,18 +18,18 @@ optional arguments:
   -e                    Edit .mailrc
 '''
 
+import argparse
 import os
 import smtplib
-import argparse
 import sys
 from ConfigParser import RawConfigParser
- 
 from email import Encoders
 from email.MIMEBase import MIMEBase
 from email.MIMEMultipart import MIMEMultipart
-from email.Utils import formatdate
 from email.MIMEText import MIMEText
- 
+from email.Utils import formatdate
+
+
 class Mail(object):
     def __init__(self,cfg_file='',verbose=False):
         #from config
@@ -64,6 +64,7 @@ class Mail(object):
         self.tls      = parser.get('mail','tls')
             
     def edit_cfg(self):
+        global _stash
         _stash('edit -t %s' %self.cfg_file)
         sys.exit(0)
         
@@ -136,10 +137,10 @@ password = Your user password
             server.close()
         except Exception, e:
             errorMsg = "Unable to send email. Error: %s" % str(e)
-        
 
- 
+
 if __name__ == "__main__":
+    APP_DIR = os.environ['STASH_ROOT']
     CONFIG = APP_DIR+'/.mailrc'
     ap = argparse.ArgumentParser()
     ap.add_argument('-s','--subject',default='',action='store',dest='subject',help='Email Subject.')
@@ -150,7 +151,7 @@ if __name__ == "__main__":
     ap.add_argument('message',action='store',default='',nargs='?',help='Email Message. Passing \'-\' will pass stdin from pipe.')
     args = ap.parse_args()
     smail = Mail(CONFIG,args.verbose)
-    if args.e == True:
+    if args.e is True:
         smail.edit_cfg()
     elif args.message or args.file and args.sendto:
         if args.message == '-':
@@ -171,5 +172,3 @@ if __name__ == "__main__":
                     subject=subject,
                     attach=file,
                     body=msg)
-        
-

--- a/bin/pip.py
+++ b/bin/pip.py
@@ -18,17 +18,13 @@ optional arguments:
   -h, --help            show this help message and exit
   -n RESULT_COUNT
 '''
+import argparse
+import os
+import shutil
+import sys
 import xmlrpclib
 from ConfigParser import SafeConfigParser
-import requests
-import argparse
-import tempfile
-import re
-import os
-import sys
-import shutil
 from types import ModuleType
-
 
 saved_modules = sys.modules
 saved_cwd = os.getcwd()
@@ -69,7 +65,7 @@ def make_module(new_module, doc="", scope=locals()):
     return sys.modules['.'.join(module_name)]
 
 def setup(*args, **kwargs):
-    global pypi
+    global _stash, pypi
     path = os.path.dirname(__file__)
     name = kwargs['name']
     version =  getattr(kwargs,'version','No version Listed')
@@ -398,7 +394,3 @@ def main():
 
 if __name__=='__main__':
     main()
-    
-
- 
-

--- a/bin/scp.py
+++ b/bin/scp.py
@@ -1,31 +1,29 @@
-'''
+"""
 Secure Copy
 Copies files from local to remote
 
 usage:
     GET
     scp [user@host:dir/file] [files/dir]
-    
+
     PUT
     scp [file/dir] [file/dir] [user@host:dir]
-'''
 
-import argparse
-# scp.py
-# Copyright (C) 2008 James Bardin <j.bardin@gmail.com>
-
-"""
 Created by jbardin
 https://github.com/jbardin/scp.py
 Utilities for sending files over ssh using the scp1 protocol.
 """
 
-__version__ = '0.8.0'
+# scp.py
+# Copyright (C) 2008 James Bardin <j.bardin@gmail.com>
 
+import argparse
 import locale
 import os
 import re
 from socket import timeout as SocketTimeout
+
+__version__ = '0.8.0'
 
 DEBUG = False
 
@@ -464,13 +462,12 @@ class SCPException(Exception):
     
 ############################################
 def find_ssh_keys():
-    #dir = os.path.expanduser('~/Documents/.ssh/')
-    files = []
-    for file in os.listdir(APP_DIR+'/.ssh'):
-        if '.' not in file:
-            files.append(APP_DIR+'/.ssh/'+file)
-    return files    
-    
+    # dir = os.path.expanduser('~/Documents/.ssh/')
+    global APP_DIR
+    ssh_dir = os.path.join(APP_DIR, '.ssh')
+    return [os.path.join(ssh_dir, file) for file in
+            os.listdir(ssh_dir) if '.' not in file]
+
 def parse_host(arg):
     user,temp = arg.split('@')
     host, path = temp.split(':')
@@ -517,6 +514,3 @@ if __name__ == '__main__':
     else:
         print 'Copying to server...'
         scp.put(files, recursive=True, remote_path=host_path)
-
-
-

--- a/bin/ssh-keygen.py
+++ b/bin/ssh-keygen.py
@@ -27,6 +27,7 @@ ap.add_argument('-f',dest='filename', default=False, action='store', help='Filen
 args = ap.parse_args()
 
 #Keygen for keypair
+APP_DIR = os.environ['STASH_ROOT']
 if not os.path.isdir(APP_DIR+'/.ssh'):
     os.mkdir(APP_DIR+'/.ssh')
     

--- a/bin/which.py
+++ b/bin/which.py
@@ -1,18 +1,18 @@
 """ Locate a command script in BIN_PATH. No output if command is not found.
 """
 
-import argparse
-
 
 def main(command):
     rt = globals()['_stash'].runtime
     try:
         filename = rt.find_script_file(command)
-        print filename
+        print(filename)
     except Exception:
         pass
 
+
 if __name__ == '__main__':
+    import argparse
     ap = argparse.ArgumentParser()
     ap.add_argument('command', help='name of the command to be located')
     ns = ap.parse_args()

--- a/tests/test05.py
+++ b/tests/test05.py
@@ -1,4 +1,4 @@
-s = _stash
+s = globals()['_stash']
 
 # following statements should be correlated
 s('echo AA is $AA')
@@ -11,7 +11,7 @@ s('cd bin')
 s('pwd -b')
 s('cd ..')
 
-print
+print('')
 # following two scripts should not interfere each other
 s('test05_1.sh')
 


### PR DESCRIPTION
On the __dev__ branch this time.  This PR replaces #295 which was on the __master__ branch.

It is time to make sure that StaSH can make the transition to Python 3.
* Add flake8 tests in the Travis CI __before_script__.
* Resolve Python 2 undefined names (flake8 F821)
* Remove a few unused imports and__isort__ed others.

Replaces both #293, #294, and #295

@jsbain @zrzka @dgelessus Your reviews please