### PR TITLE
Start testing on Python 3 in allow_failures mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,19 @@
 language: python
 python:
   - "2.7"
+  - "3.6"
+matrix:
+  allow_failures:
+    - python: "3.6"
 # command to install dependencies
 install:
   - "pip install pyparsing==2.0.1"
-  - "pip install pytest>=2.8.1"
+  - "pip install pytest>=3.5.0"
+  - "pip install flake8>=3.5.0"
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 # command to run tests
 script: py.test system/tests --ignore=system/tests/data

--- a/bin/cp.py
+++ b/bin/cp.py
@@ -7,6 +7,8 @@ from __future__ import print_function
 import argparse
 import os
 import shutil
+import sys
+
 
 def pprint(path):
     if path.startswith(os.environ['HOME']):

--- a/bin/crypt.py
+++ b/bin/crypt.py
@@ -13,18 +13,19 @@ optional arguments:
   -k KEY, --key KEY  Encrypt/Decrypt Key.
   -d, --decrypt      Flag to decrypt.
 '''
-import os
 import argparse
 import base64
+import os
 
+_stash = globals()['_stash']
 try:
-	import pyaes
-except:
-	print 'Installing Required packages.'
-	_stash('pip install pyaes')
-	import pyaes
+    import pyaes
+except Exception:
+    print 'Installing Required packages.'
+    _stash('pip install pyaes')
+    import pyaes
 
-	
+
 class Crypt(object):
 	def __init__(self, in_filename, out_filename=None):
 		self.in_filename = in_filename

--- a/bin/gh.py
+++ b/bin/gh.py
@@ -10,9 +10,12 @@ supported commands are:
 	gh create_key <title> [<public_key_path>] add a key to github (or create new key if none exist)
 For all commands, use gh <command> --help for more detailed help
 
-NOTE: assumes a keychain user/pass stored in 	keychainservice='stash.git.github.com', which is also the default from the git module.  
-
+NOTE: assumes a keychain user/pass stored in 	keychainservice='stash.git.github.com', which is also the default from the git module.
 '''
+import os
+import sys
+
+
 def install_module_from_github(username, package_name, folder, version):
     """
     Install python module from github zip files

--- a/bin/git.py
+++ b/bin/git.py
@@ -23,28 +23,35 @@ Commands:
     help: git help
 '''
 
+import argparse
+import os
+import posix
+import subprocess
+import sys
+import urlparse
+from io import StringIO
+
+import console
+import editor  # for reloading current file
+import keychain
+
+_stash = globals()['_stash']
 SAVE_PASSWORDS = True
 
-import argparse
-import urlparse,urllib2,keychain
-import sys,os,posix
-import editor #for reloading current file
 # temporary -- install required modules
-
-#needed for dulwich: subprocess needs to have Popen
-import subprocess
+# needed for dulwich: subprocess needs to have Popen
 if not hasattr(subprocess,'call'):
-	def Popen(*args,**kwargs):
-		pass
-	def call(*args,**kwargs):
-		return 0
-	subprocess.Popen=Popen
-	subprocess.call=call
+    def Popen(*args,**kwargs):
+        pass
+    def call(*args,**kwargs):
+        return 0
+    subprocess.Popen=Popen
+    subprocess.call=call
 GITTLE_URL='https://github.com/jsbain/gittle/archive/master.zip'
 FUNKY_URL='https://github.com/FriendCode/funky/archive/master.zip'
 DULWICH_URL='https://github.com/jsbain/dulwich/archive/ForStaSH_0.12.2.zip'
 REQUIRED_DULWICH_VERSION = (0,12,2)
-AUTODOWNLOAD_DEPENDENCIES = True 
+AUTODOWNLOAD_DEPENDENCIES = True
 
 if AUTODOWNLOAD_DEPENDENCIES:
     libpath=os.path.join(os.environ['STASH_ROOT'] ,'lib')

--- a/bin/grep.py
+++ b/bin/grep.py
@@ -9,6 +9,7 @@ import re
 import sys
 
 def main(args):
+    global _stash
     ap = argparse.ArgumentParser()
     ap.add_argument('pattern', help='the pattern to match')
     ap.add_argument('files', nargs='*', help='files to be searched')

--- a/bin/latte.py
+++ b/bin/latte.py
@@ -1,17 +1,20 @@
 # A package manager meant for Pythonista, built on StaSh.
+from __future__ import print_function
+
+import argparse
+import sys
+from os import getcwd, mkdir, remove, rename
+from shutil import rmtree
 
 import requests
-import sys
-import argparse
-from os import remove, mkdir, rename, listdir, getcwd
-from shutil import rmtree
 
 cwd = getcwd()
 documentsIndex = cwd.index("Documents")
 documentsIndex += len("Documents")
 ROOT = cwd[:documentsIndex]
 
-class stansi: # Collection of Stash's ANSI escape codes.
+
+class stansi:  # Collection of Stash's ANSI escape codes.
 	bold = u"\x9b1m"
 	underscore = u"\x9b4m"
 	attr_end = u"\x9b0m"
@@ -104,7 +107,7 @@ def main(sargs):
 		try:
 			download_package(repo_to_use, package_name)
 		except:
-			stoutput("ERROR", "Couldn't find package", "error")
+			print("ERROR", "Couldn't find package", "error")
 			sys.exit()
 		# Move to correct locations
 		print("Installing")

--- a/bin/mail.py
+++ b/bin/mail.py
@@ -67,6 +67,7 @@ class Mail(object):
         self.tls      = parser.get('mail','tls')
             
     def edit_cfg(self):
+        global _stash
         _stash('edit -t %s' %self.cfg_file)
         sys.exit(0)
         
@@ -175,4 +176,3 @@ if __name__ == "__main__":
                     attach=file,
                     body=msg)
         
-

--- a/bin/which.py
+++ b/bin/which.py
@@ -1,10 +1,9 @@
 """ Locate a command script in BIN_PATH. No output if command is not found.
 """
 
-import argparse
-
 
 def main(command, fullname=False):
+    global _stash
     rt = globals()['_stash'].runtime
     try:
         filename = rt.find_script_file(command)
@@ -14,7 +13,9 @@ def main(command, fullname=False):
     except Exception:
         pass
 
+
 if __name__ == '__main__':
+    import argparse
     ap = argparse.ArgumentParser()
     ap.add_argument('command', help='name of the command to be located')
     ap.add_argument('-f', '--fullname', action='store_true',

--- a/lib/git/git-merge.py
+++ b/lib/git/git-merge.py
@@ -1,12 +1,14 @@
 
-from dulwich.diff_tree import _tree_entries, _NULL_ENTRY, TreeEntry, _is_tree
-from gittle import Gittle
-from dulwich import porcelain
-import stat
-from git import diff3
-from git.gitutils import _get_repo, find_revision_sha, can_ff, merge_base, count_commits_between, is_ancestor, get_remote_tracking_branch, GitError
 import argparse
+import os
+import stat
 
+from dulwich import porcelain
+from dulwich.diff_tree import _NULL_ENTRY, TreeEntry, _is_tree, _tree_entries
+from git import diff3, git_reset
+from git.gitutils import (GitError, _get_repo, count_commits_between,
+                          find_revision_sha, get_remote_tracking_branch,
+                          merge_base)
 
 
 def _merge_entries(path, trees):
@@ -219,4 +221,3 @@ def merge(args):
 if __name__=='__main__':
     import sys
     merge(sys.argv[1:])
-    


### PR DESCRIPTION
On the __dev__ branch this time.  This PR replaces #295 which was on the __master__ branch.

It is time to make sure that StaSH can make the transition to Python 3.
* Add flake8 tests in the Travis CI __before_script__.
* Resolve Python 2 undefined names (flake8 F821)
* Remove a few unused imports and ran __isort__ on others.
* Fix #296 with __print()__

Replaces both #293, #294, and #295