### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/bin/clear.py
+++ b/bin/clear.py
@@ -1,2 +1,3 @@
 """Clear the stash console output window"""
-print u'\u009bc',
+from __future__ import print_function
+print(u'\u009bc', end=' ')

--- a/bin/cowsay.py
+++ b/bin/cowsay.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #by Siddharth Duahantha
 #28 July 2017
 from sys import argv

--- a/bin/crypt.py
+++ b/bin/crypt.py
@@ -13,6 +13,7 @@ optional arguments:
   -k KEY, --key KEY  Encrypt/Decrypt Key.
   -d, --decrypt      Flag to decrypt.
 '''
+from __future__ import print_function
 import argparse
 import base64
 import os
@@ -21,7 +22,7 @@ _stash = globals()['_stash']
 try:
     import pyaes
 except Exception:
-    print 'Installing Required packages.'
+    print('Installing Required packages.')
     _stash('pip install pyaes')
     import pyaes
 
@@ -70,4 +71,4 @@ if __name__ == '__main__':
 	else:
 		nk = crypt.aes_encrypt(args.key)
 		if args.key is None:
-			print "Key: ", nk
+			print("Key: ", nk)

--- a/bin/curl.py
+++ b/bin/curl.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """ Transfer a URL
 """
+from __future__ import print_function
 import sys
 import argparse
 import requests
@@ -35,14 +36,14 @@ def main(args):
     elif ns.request_method == 'HEAD':
         r = requests.head(url, headers=headers)
     else:
-        print 'unknown request method: {}'.format(ns.request_method)
+        print('unknown request method: {}'.format(ns.request_method))
         return
 
     if ns.output_file:
         with open(ns.output_file, 'w') as outs:
             outs.write(r.text)
     else:
-        print r.text
+        print(r.text)
 
 
 if __name__ == '__main__':

--- a/bin/cut.py
+++ b/bin/cut.py
@@ -1,5 +1,6 @@
 """ Print selected parts of lines from each FILE to standard output.
 """
+from __future__ import print_function
 import os
 import sys
 import argparse
@@ -41,15 +42,15 @@ def main(args):
     for infields in _stash.libcore.input_stream(ns.files):
         if infields[0] is None:
             _, filename, e = infields
-            print '%s: %s' % (filename, repr(e))
+            print('%s: %s' % (filename, repr(e)))
         else:
             line, filename, lineno = infields
             fields = line.split(ns.delimiter)
             if len(fields) == 1:
-                print fields[0]
+                print(fields[0])
             else:
                 out = ' '.join((' '.join(fields[sidx:eidx]) for sidx, eidx in indices))
-                print out
+                print(out)
 
 if __name__ == '__main__':
     main(sys.argv[1:])

--- a/bin/dropbox_setup.py
+++ b/bin/dropbox_setup.py
@@ -2,6 +2,7 @@
 # StaSh utility
 
 """manage your dropbox configuration."""
+from __future__ import print_function
 
 import cmd
 import keychain
@@ -28,11 +29,11 @@ class DropboxSetupCmd(cmd.Cmd):
 
 	def do_list(self, cmd):
 		"""list: lists the dropbox usernames."""
-		print
+		print()
 		for service, account in keychain.get_services():
 			if service == dbutils.DB_SERVICE:
-				print account
-		print
+				print(account)
+		print()
 
 	def do_del(self, cmd):
 		"""del USERNAME: resets the dropbox for USERNAME."""

--- a/bin/du.py
+++ b/bin/du.py
@@ -1,5 +1,6 @@
 """ Summarize disk usage of the set of FILEs, recursively for directories.
 """
+from __future__ import print_function
 import os
 import sys
 from argparse import ArgumentParser
@@ -71,9 +72,9 @@ def main(args):
                 if ns.summarize and root != path:
                     continue
 
-                print '%-8s %s' % (sizeof_fmt(my_size), root)
+                print('%-8s %s' % (sizeof_fmt(my_size), root))
         else:
-            print '%-8s %s' % (sizeof_fmt(os.path.getsize(path)), path)
+            print('%-8s %s' % (sizeof_fmt(os.path.getsize(path)), path))
 
 
 if __name__ == '__main__':

--- a/bin/easy_config.py
+++ b/bin/easy_config.py
@@ -1,13 +1,14 @@
 """a graphical config manager for StaSh"""
-import os
 import ast
+import os
 import threading
+
+from six import string_types
+
 import console
-import ui
-
-from stash.system.shcommon import _STASH_CONFIG_FILES
 import pythonista_add_action as paa
-
+import ui
+from stash.system.shcommon import _STASH_CONFIG_FILES
 
 _stash = globals()["_stash"]
 
@@ -455,7 +456,7 @@ class ConfigView(ui.View):
 			b = ui.Button()
 			b.title = info["display_name"]
 			cmd = info["command"]
-			if isinstance(cmd, (str, unicode)):
+			if isinstance(cmd, string_types):
 				f = lambda c=cmd: _stash(c, add_to_history=False)
 			else:
 				f = lambda c=cmd: cmd()

--- a/bin/edit.py
+++ b/bin/edit.py
@@ -7,12 +7,17 @@ usage:
     edit [-t --temp] [-o --old_tab] [file]
     Follow prompt for instructions.
 """
+from __future__ import print_function
+
+import argparse
 import os
 import tempfile
+import time
+
+from six.moves import input
+
 import console
 import editor
-import time
-import argparse
 
 
 def open_temp(file='', new_tab=True):
@@ -30,34 +35,34 @@ def open_temp(file='', new_tab=True):
             temp.flush()
             to_edit.close()
             
-        print '***When you are finished editing the file, you must come back to console to confim changes***'
+        print('***When you are finished editing the file, you must come back to console to confim changes***')
         editor.open_file(temp.name, new_tab)
         time.sleep(1.5)
         console.hide_output()
-        input = raw_input('Save Changes? Y,N: ')
+        user_input = input('Save Changes? Y,N: ')
     
-        if input=='Y' or input=='y':
+        if user_input in 'Yy':
             while True:
                 try:
-                    save_as = raw_input('Save file as [Enter to confirm]: %s' % file_to_edit) or file_to_edit
+                    save_as = input('Save file as [Enter to confirm]: %s' % file_to_edit) or file_to_edit
                 except:
                     save_as = file_to_edit
                 if save_as:
                     break
 
             if not new_tab:
-                editor.open_file(cur_path) # restore previous script in editor
+                editor.open_file(cur_path)  # restore previous script in editor
             with open(save_as,'w') as f:
                 with open(temp.name,'r') as tmp:
                     f.write(tmp.read())
                     
-            print 'File Saved.'
-        elif input=='N' or input=='n':
+            print('File Saved.')
+        elif user_input in 'Nn':
             if not new_tab:
-                editor.open_file(cur_path) # restore previous script in editor
+                editor.open_file(cur_path)  # restore previous script in editor
     
-    except Exception, e:
-        print e
+    except Exception as e:
+        print(e)
         
     finally:
         temp.close()

--- a/bin/fg.py
+++ b/bin/fg.py
@@ -1,6 +1,7 @@
 """
 Bring a background job to foreground.
 """
+from __future__ import print_function
 import sys
 import argparse
 import threading
@@ -20,15 +21,15 @@ def main(args):
         worker = worker_registry.get_worker(ns.job_id)
 
     if worker is None:
-        print 'no background job running' \
-              + (' with id {}'.format(ns.job_id) if ns.job_id else '')
+        print('no background job running' \
+              + (' with id {}'.format(ns.job_id) if ns.job_id else ''))
         return
 
     def f():
         _stash.runtime.push_to_foreground(worker)
 
     t = threading.Timer(1.0, f)
-    print 'pushing job {} to foreground ...'.format(worker.job_id)
+    print('pushing job {} to foreground ...'.format(worker.job_id))
     t.start()
 
 if __name__ == '__main__':

--- a/bin/find.py
+++ b/bin/find.py
@@ -1,5 +1,6 @@
 """ Find files in specified paths
 """
+from __future__ import print_function
 
 import os
 import sys
@@ -112,7 +113,7 @@ def main(args):
     ap.add_argument('-maxdepth', '--maxdepth',
                     metavar='n',
                     nargs='?',
-                    default=sys.maxint,
+                    default=sys.maxsize,
                     type=int,
                     help='descend at most n directory levels below command line arguments')
     ns = ap.parse_args(args)
@@ -140,7 +141,7 @@ def main(args):
 
     names = file_predicate.run(ns.paths)
 
-    print '\n'.join(names)
+    print('\n'.join(names))
 
 
 if __name__ == "__main__":

--- a/bin/ftpserver.py
+++ b/bin/ftpserver.py
@@ -1,4 +1,5 @@
 """Simple FTP Server"""
+from __future__ import print_function
 import argparse
 import os
 import sys

--- a/bin/gh.py
+++ b/bin/gh.py
@@ -12,8 +12,11 @@ For all commands, use gh <command> --help for more detailed help
 
 NOTE: assumes a keychain user/pass stored in 	keychainservice='stash.git.github.com', which is also the default from the git module.
 '''
+from __future__ import print_function
 import os
 import sys
+
+from six.moves import input
 
 
 def install_module_from_github(username, package_name, folder, version):
@@ -42,7 +45,7 @@ try:
         sys.path.insert(1,libpath)
     import github
 except ImportError:
-    print 'no github found in ',libpath
+    print('no github found in ',libpath)
     install_module_from_github('pygithub', 'pygithub', 'github','master')
     import github
 try: 
@@ -69,7 +72,7 @@ def command(func):
        	 args=docopt(func.__doc__,argv=argv)
        	 return func(args)
        except SystemExit as e:
-       	print e
+       	print(e)
 
     return tmp
 
@@ -176,8 +179,8 @@ Examples:
 		if args['--issue']:
 			kwargs['issue']=baserepo.get_issue(args['--issue'])
 		elif not args['--title']:
-			kwargs['title']=raw_input('Enter pull title:')
-			kwargs['body']=raw_input('Enter pull body:')
+			kwargs['title']=input('Enter pull title:')
+			kwargs['body']=input('Enter pull body:')
 		else:
 			kwargs['title']=args['--title']
 			kwargs['body']=args['--body'] or ''

--- a/bin/git.py
+++ b/bin/git.py
@@ -16,20 +16,23 @@ Commands:
     fetch: git fetch [uri or remote] - fetch changes from remote
     checkout: git checkout <branch> - check out a particular branch in the Git tree
     branch: git branch - show branches
-    remote: git remote [remotename remoteuri]- list or add remote repos 
+    remote: git remote [remotename remoteuri]- list or add remote repos
     status: git status - show status of files (staged unstaged untracked)
     reset: git reset - reset a repo to its pre-change state
     diff: git diff - show changes in staging area
     help: git help
 '''
+from __future__ import print_function
 
 import argparse
 import os
 import posix
 import subprocess
 import sys
-import urlparse
-from io import StringIO
+
+from six import StringIO
+from six.moves import input
+from six.moves.urllib.parse import urlparse
 
 import console
 import editor  # for reloading current file
@@ -47,6 +50,7 @@ if not hasattr(subprocess,'call'):
         return 0
     subprocess.Popen=Popen
     subprocess.call=call
+
 GITTLE_URL='https://github.com/jsbain/gittle/archive/master.zip'
 FUNKY_URL='https://github.com/FriendCode/funky/archive/master.zip'
 DULWICH_URL='https://github.com/jsbain/dulwich/archive/ForStaSH_0.12.2.zip'
@@ -66,7 +70,7 @@ if AUTODOWNLOAD_DEPENDENCIES:
         from dulwich import porcelain
         from dulwich.index import index_entry_from_stat
         if not dulwich.__version__ ==  REQUIRED_DULWICH_VERSION:
-            print 'Dulwich version was {}.  Required is {}.  Attempting to reload'.format(dulwich.__version__,REQUIRED_DULWICH_VERSION)
+            print('Dulwich version was {}.  Required is {}.  Attempting to reload'.format(dulwich.__version__,REQUIRED_DULWICH_VERSION))
             for m in [m for m in sys.modules if m.startswith('dulwich')]:
                 del sys.modules[m]
             import dulwich
@@ -74,16 +78,16 @@ if AUTODOWNLOAD_DEPENDENCIES:
             from dulwich import porcelain
             from dulwich.index import index_entry_from_stat
             if not dulwich.__version__ ==  REQUIRED_DULWICH_VERSION:
-                print 'Could not find correct version. Will download proper fork now'
+                print('Could not find correct version. Will download proper fork now')
                 download_dulwich = True
             else:
-                print 'Correct version loaded.'
+                print('Correct version loaded.')
     except ImportError as e:
-        print 'dulwich was not found.  Will attempt to download. '
+        print('dulwich was not found.  Will attempt to download. ')
         download_dulwich = True 
     try:
         if download_dulwich:
-            if not raw_input('Need to download dulwich.  OK to download [y/n]?') == 'y':
+            if not input('Need to download dulwich.  OK to download [y/n]?') == 'y':
                 raise ImportError()
             _stash('wget {} -o $TMPDIR/dulwich.zip'.format(DULWICH_URL))
             _stash('unzip $TMPDIR/dulwich.zip -d $TMPDIR/dulwich')
@@ -109,9 +113,9 @@ if AUTODOWNLOAD_DEPENDENCIES:
             from dulwich import porcelain
             from dulwich.index import index_entry_from_stat
     except Exception:
-        print '''Still could not import dulwich.
+        print('''Still could not import dulwich.
             Perhaps your network connection was unavailable.
-            You might also try deleting any existing dulwich versions in site-packages or elsewhere, then restarting pythonista.'''
+            You might also try deleting any existing dulwich versions in site-packages or elsewhere, then restarting pythonista.''')
 
     #gittle, funky
     # todo... check gittle version
@@ -198,7 +202,7 @@ def _confirm_dangerous():
         repo = _get_repo()
         status=porcelain.status(repo.path)
         if any(status.staged.values()+status.unstaged):
-            force=raw_input('WARNING: there are uncommitted modified files and/or staged changes. These could be overwritten by this command. Continue anyway? [y/n] ')
+            force=input('WARNING: there are uncommitted modified files and/or staged changes. These could be overwritten by this command. Continue anyway? [y/n] ')
             if not force=='y':
                 raise Exception('User cancelled dangerous operation')
                 
@@ -219,7 +223,7 @@ def unstage(commit='HEAD',paths=[]):
                 del(index[path])
                 index.write()
             except KeyError:
-                print 'file not in index.',path
+                print('file not in index.',path)
             return
             
         try:
@@ -256,33 +260,33 @@ def git_init(args):
     if len(args) == 1:
         Gittle.init(args[0])
     else:
-        print command_help['init']
+        print(command_help['init'])
 
 def git_status(args):
     if len(args) == 0:
         repo = _get_repo()
         status = porcelain.status(repo.repo.path)
-        print 'STAGED'
+        print('STAGED')
         for k,v in status.staged.iteritems():
             if v:
-                print k,v
-        print 'UNSTAGED LOCAL MODS'
-        print status.unstaged
+                print(k,v)
+        print('UNSTAGED LOCAL MODS')
+        print(status.unstaged)
         
     else:
-        print command_help['status']
+        print(command_help['status'])
 
 def git_remote(args):
     '''List remote repos'''
     if len(args) == 0:
         repo = _get_repo()
         for key, value in repo.remotes.items():
-            print '{} {}'.format(key, value)
+            print('{} {}'.format(key, value))
     elif len(args)==2:
         repo=_get_repo()
         repo.add_remote(args[0],args[1])
     else:
-        print command_help['remote']
+        print(command_help['remote'])
 
 def git_add(args):
     if len(args) > 0:
@@ -295,13 +299,13 @@ def git_add(args):
         for file in args:
             
             if os.path.exists(os.path.join(repo.repo.path, file)):
-                print 'Adding {0}'.format(file)
+                print('Adding {0}'.format(file))
                 porcelain.add(repo.repo.path, [file])
             else:
-                print '{} does not exist. skipping'.format(file)
+                print('{} does not exist. skipping'.format(file))
 
     else:
-        print command_help['add']
+        print(command_help['add'])
 
 def git_rm(args):
     if len(args) > 0:
@@ -310,12 +314,12 @@ def git_rm(args):
         args = [os.path.join(os.path.relpath(cwd, repo.path), x)
                     if not os.path.samefile(cwd, repo.path) else x for x in args]
         for file in args:
-            print 'Removing {0}'.format(file)
+            print('Removing {0}'.format(file))
             #repo.rm(args)
             porcelain.rm(repo.repo.path, args)
 
     else:
-        print command_help['rm']
+        print(command_help['rm'])
 def launch_subcmd(cmd,args):
     cmdpath=os.path.join(os.environ['STASH_ROOT'],'lib','git',cmd)
 
@@ -367,10 +371,10 @@ def git_reset(args):
         if commit == 'HEAD':
             commit = repo.head
         elif commit in repo.branches:
-            print 'updating HEAD to ', commit
+            print('updating HEAD to ', commit)
             repo.repo.refs.set_symbolic_ref('HEAD',repo._format_ref_branch(commit))
         else:
-            print commit, 'is not a valid branchname.  head was not updated'
+            print(commit, 'is not a valid branchname.  head was not updated')
     if ns.hard:
         _confirm_dangerous()
  
@@ -379,16 +383,16 @@ def git_reset(args):
         if paths:
             unstage(commit,paths)
         else:
-            print 'resetting index. please wait'
+            print('resetting index. please wait')
             unstage_all(commit)
-            print 'complete'
+            print('complete')
  
     # next, rebuild files
     if ns.hard:
         treeobj=repo[repo[commit].tree]
         
         for path in paths:
-            print 'resetting '+path
+            print('resetting '+path)
             relpath=repo.relpath(path)
             file_contents=repo[treeobj.lookup_path(repo.__getitem__,relpath)[1]].as_raw_string()
             with open(str(path),'w') as f:
@@ -399,9 +403,9 @@ def get_config_or_prompt(repo, section, name, prompt, save=None):
     try:
         value = config.get(section, name)
     except KeyError:
-        value = raw_input(prompt)
+        value = input(prompt)
         if save == None:
-            reply = raw_input('Save this setting? [y/n]')
+            reply = input('Save this setting? [y/n]')
             save = reply == 'y'
         if save:
             config.set(section, name, value)
@@ -419,13 +423,13 @@ def git_commit(args):
     merging = repo.repo.get_named_file('MERGE_HEAD')
     merge_head=None
     if merging:
-        print 'merging in process:' 
+        print('merging in process:') 
         merge_head= merging.read() or ''
         merge_msg= repo.repo.get_named_file('MERGE_MSG').read() or ''
-        print merge_msg
+        print(merge_msg)
         ns.message = ns.message or '' + merge_msg
     if not ns.message:
-        ns.message=raw_input('Commit Message: ')
+        ns.message=input('Commit Message: ')
 
     ns.name = ns.name or get_config_or_prompt(repo, 'user', 'name', 'Author Name: ')
     ns.email = ns.email or get_config_or_prompt(repo, 'user', 'email', 'Author Email: ')
@@ -434,10 +438,10 @@ def git_commit(args):
     
         author = "{0} <{1}>".format(ns.name, ns.email)
 
-        print repo.repo.do_commit(message=ns.message
+        print(repo.repo.do_commit(message=ns.message
                                   , author=author
                                   , committer=author 
-                                  , merge_heads=[merge_head] if merge_head else None)
+                                  , merge_heads=[merge_head] if merge_head else None))
         if merging:
             try:
                 os.remove(os.path.join(repo.repo.controldir(),'MERGE_HEAD'))
@@ -445,7 +449,7 @@ def git_commit(args):
             except OSError:
                 pass  #todo, just no such file
     except:
-        print 'commit Error: {0}'.format(sys.exc_value)
+        print('commit Error: {0}'.format(sys.exc_info()[1]))
 
     
 
@@ -460,7 +464,7 @@ def git_clone(args):
            config.write_to_path()
           
     else:
-        print command_help['clone']
+        print(command_help['clone'])
 
 def git_pull(args):
     if len(args) <= 1:
@@ -475,9 +479,9 @@ def git_pull(args):
         if url:
             repo.pull(origin_uri=url)
         else:
-            print 'No pull URL.'
+            print('No pull URL.')
     else:
-        print command_help['git pull']
+        print(command_help['git pull'])
 
 def git_fetch(args): 
     parser = argparse.ArgumentParser(prog='git fetch'
@@ -497,9 +501,9 @@ def git_fetch(args):
         result.url=repo.remotes.get(origin)
     if not urlparse.urlparse(result.url).scheme:
         raise Exception('url must match a remote name, or must start with http:// or https://')
-    print 'Starting fetch, this could take a while'
+    print('Starting fetch, this could take a while')
     remote_refs=porcelain.fetch(repo.repo.path,result.url)
-    print 'Fetch successful.  Importing refs'
+    print('Fetch successful.  Importing refs')
     remote_tags = gittle.utils.git.subrefs(remote_refs, 'refs/tags')
     remote_heads = gittle.utils.git.subrefs(remote_refs, 'refs/heads')
         
@@ -516,21 +520,21 @@ def git_fetch(args):
         clean_remote_heads
     )
     for k,v in clean_remote_heads.items():
-        print 'imported {}/{} {}'.format(heads_base,k,v) 
+        print('imported {}/{} {}'.format(heads_base,k,v)) 
     # Import tags
     repo.import_refs(
         'refs/tags',
         clean_remote_tags
     )
     for k,v in clean_remote_tags.items():
-        print 'imported {}/{} {}'.format('refs/tags',k,v) 
-    print 'Checking for deleted remote refs'
+        print('imported {}/{} {}'.format('refs/tags',k,v)) 
+    print('Checking for deleted remote refs')
     #delete unused remote refs
     for k in gittle.utils.git.subrefs(repo.refs,heads_base):
         if k not in clean_remote_heads:
-            print 'Deleting {}'.format('/'.join([heads_base,k]))
+            print('Deleting {}'.format('/'.join([heads_base,k])))
             del repo.refs['/'.join([heads_base,k])]
-    print 'Fetch complete'
+    print('Fetch complete')
 
 def git_push(args):
     parser = argparse.ArgumentParser(prog='git push'
@@ -553,7 +557,7 @@ def git_push(args):
 
     branch_name = os.path.join('refs','heads', repo.active_branch)  #'refs/heads/%s' % repo.active_branch
 
-    print "Attempting to push to: {0}, branch: {1}".format(result.url, branch_name)
+    print("Attempting to push to: {0}, branch: {1}".format(result.url, branch_name))
 
     netloc = urlparse.urlparse(result.url).netloc
 
@@ -570,8 +574,8 @@ def git_push(args):
         try:
             user = dict(keychain.get_services())[keychainservice]
         except KeyError:
-            user = raw_input('Enter username: ')
-            pw = raw_input('Enter password: ')
+            user = input('Enter username: ')
+            pw = input('Enter password: ')
             #user, pw = console.login_alert('Enter credentials for {0}'.format(netloc))
 
     outstream = StringIO()
@@ -593,14 +597,14 @@ def git_push(args):
         porcelain.push(repo.repo.path, result.url, branch_name, errstream=outstream)
  
     for line in outstream.getvalue().split('\n'):
-        print(line.replace(pw, '*******') if pw else line)
+        print((line.replace(pw, '*******') if pw else line))
     
-    print 'success!'
+    print('success!')
 
 def git_modified(args):
     repo = _get_repo()
     for mod_file in repo.modified_files:
-        print mod_file
+        print(mod_file)
 
 def git_log(args):
     parser = argparse.ArgumentParser(description='git log arg parser')
@@ -633,7 +637,7 @@ def git_log(args):
         porcelain.log(repo.repo.path, max_entries=results.max_entries,outstream=outstream)
         
         if not results.oneline:
-            print outstream.getvalue()
+            print(outstream.getvalue())
         else:
 
             last_commit = ''
@@ -662,7 +666,7 @@ def git_log(args):
                     
                     
     except ValueError:
-        print command_help['log']
+        print(command_help['log'])
 
 def git_diff(args):
     '''prints diff of currently staged files to console.. '''
@@ -697,14 +701,14 @@ def git_checkout(args):
         if len(args) == 2:
             if args[0] == '-b':
                 #TODO: Add tracking as a parameter
-                print "Creating branch {0}".format(args[1])
+                print("Creating branch {0}".format(args[1]))
                 repo.create_branch(repo.active_branch, args[1], tracking=None)
                 #Recursive call to checkout the branch we just created
                 git_checkout([args[1]])
         else:
             refresh_editor()
     else:
-        print command_help['checkout']
+        print(command_help['checkout'])
         
 def refresh_editor():
     #reload current file in editor
@@ -717,12 +721,12 @@ def refresh_editor():
         editor.replace_text(sel[0],sel[0],'') #force scroll
         editor.set_selection(sel[0],sel[1])
     except:
-        print 'Could not refresh editor.  continuing anyway'
+        print('Could not refresh editor.  continuing anyway')
     
 def git_help(args):
-    print 'help:'
+    print('help:')
     for key, value in command_help.items():
-        print value
+        print(value)
             
            
 

--- a/bin/httpserver.py
+++ b/bin/httpserver.py
@@ -8,26 +8,24 @@ This module builds on BaseHTTPServer by implementing the standard GET
 and HEAD requests in a fairly straightforward manner.
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
+
+import cgi
+import mimetypes
+import os
+import posixpath
+import re
+import shutil
+
+from six import StringIO
+from six.moves import BaseHTTPServer
+from six.moves.urllib.parse import quote, unquote
 
 __version__ = "0.1"
 __all__ = ["SimpleHTTPRequestHandler"]
 __author__ = "bones7456"
 __home_page__ = "http://li2z.cn/"
 
-import os
-import posixpath
-import BaseHTTPServer
-import urllib
-import cgi
-import shutil
-import mimetypes
-import re
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from StringIO import StringIO
-    
 
 class SimpleHTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
 
@@ -61,7 +59,7 @@ class SimpleHTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
     def do_POST(self):
         """Serve a POST request."""
         r, info = self.deal_post_data()
-        print r, info, "by: ", self.client_address
+        print(r, info, "by: ", self.client_address)
         f = StringIO()
         f.write('<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">')
         f.write("<html>\n<title>Upload Result Page</title>\n")
@@ -185,7 +183,7 @@ class SimpleHTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             return None
         list.sort(key=lambda a: a.lower())
         f = StringIO()
-        displaypath = cgi.escape(urllib.unquote(self.path))
+        displaypath = cgi.escape(unquote(self.path))
         f.write('<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">')
         f.write("<html>\n<title>Directory listing for %s</title>\n" % displaypath)
         f.write("<body>\n<h2>Directory listing for %s</h2>\n" % displaypath)
@@ -205,7 +203,7 @@ class SimpleHTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                 displayname = name + "@"
                 # Note: a link to a directory displays with @ and links with /
             f.write('<li><a href="%s">%s</a>\n'
-                    % (urllib.quote(linkname), cgi.escape(displayname)))
+                    % (quote(linkname), cgi.escape(displayname)))
         f.write("</ul>\n<hr>\n</body>\n</html>\n")
         length = f.tell()
         f.seek(0)
@@ -226,7 +224,7 @@ class SimpleHTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         # abandon query parameters
         path = path.split('?',1)[0]
         path = path.split('#',1)[0]
-        path = posixpath.normpath(urllib.unquote(path))
+        path = posixpath.normpath(unquote(path))
         words = path.split('/')
         words = filter(None, words)
         path = os.getcwd()
@@ -291,12 +289,12 @@ def main(port=8000):
     server = BaseHTTPServer.HTTPServer(('0.0.0.0', port), SimpleHTTPRequestHandler)
     
     try:
-        print 'Serving HTTP on 0.0.0.0 port %d ...' % port
-        print 'local IP address is %s' % globals()['_stash'].libcore.get_lan_ip()
+        print('Serving HTTP on 0.0.0.0 port %d ...' % port)
+        print('local IP address is %s' % globals()['_stash'].libcore.get_lan_ip())
         server.serve_forever()
 
     except KeyboardInterrupt:
-        print 'Server shutting down ...'
+        print('Server shutting down ...')
         server.server_close()
 
 if __name__ == '__main__':
@@ -305,4 +303,3 @@ if __name__ == '__main__':
     ap.add_argument('port', nargs='?', type=int, default=8000, help='port to server HTTP')
     ns = ap.parse_args()
     main(ns.port)
-

--- a/bin/jobs.py
+++ b/bin/jobs.py
@@ -1,6 +1,7 @@
 """
 List all jobs that are currently running.
 """
+from __future__ import print_function
 import sys
 import argparse
 import threading
@@ -16,7 +17,7 @@ def main(args):
 
     for worker in _stash.get_workers():
         if worker.job_id != current_worker.job_id:
-            print worker
+            print(worker)
 
 
 if __name__ == '__main__':

--- a/bin/kill.py
+++ b/bin/kill.py
@@ -1,6 +1,7 @@
 """
 Terminate a running job.
 """
+from __future__ import print_function
 import sys
 import argparse
 import time
@@ -16,13 +17,13 @@ def main(args):
 
     for job_id in ns.job_ids:
         if job_id in _stash.runtime.worker_registry:
-            print 'killing job {} ...'.format(job_id)
+            print('killing job {} ...'.format(job_id))
             worker = _stash.runtime.worker_registry.get_worker(job_id)
             worker.kill()
             time.sleep(1)
 
         else:
-            print 'error: no such job with id: {}'.format(job_id)
+            print('error: no such job with id: {}'.format(job_id))
             break
 
 

--- a/bin/ls.py
+++ b/bin/ls.py
@@ -1,4 +1,5 @@
 """List information about files (the current directory by default)"""
+from __future__ import print_function
 import os
 import sys
 import time
@@ -124,7 +125,7 @@ def main(args):
 
     if len(ns.files) == 0:
         out = joiner.join(_fmt(f) for f in os.listdir('.') if _filter(f))
-        print out
+        print(out)
 
     else:
         out_dir = []
@@ -142,12 +143,12 @@ def main(args):
                 out_file.append(_fmt(f))
 
         for o in out_miss:
-            print o
-        print joiner.join(out_file)
+            print(o)
+        print(joiner.join(out_file))
         if out_file:
-            print
+            print()
         for o in out_dir:
-            print o
+            print(o)
     sys.exit(exitcode)
 
 

--- a/bin/mail.py
+++ b/bin/mail.py
@@ -18,21 +18,24 @@ optional arguments:
   -f FILE, --file FILE  Attachment to send.
   -e                    Edit .mailrc
 '''
+from __future__ import print_function
 
+import argparse
 import os
 import smtplib
-import argparse
 import sys
-from ConfigParser import RawConfigParser
- 
 from email import Encoders
-from email.MIMEBase import MIMEBase
-from email.MIMEMultipart import MIMEMultipart
-from email.Utils import formatdate
-from email.MIMEText import MIMEText
+from email.utils import formatdate
+
+from six.moves import input
+from six.moves.configparser import RawConfigParser
+from six.moves.email_mime_base import MIMEBase
+from six.moves.email_mime_multipart import MIMEMultipart
+from six.moves.email_mime_text import MIMEText
 
 APP_DIR = os.environ['STASH_ROOT']
- 
+
+
 class Mail(object):
     def __init__(self,cfg_file='',verbose=False):
         #from config
@@ -49,13 +52,13 @@ class Mail(object):
         
     def _print(self,msg):
         if self.verbose:
-            print msg
+            print(msg)
             
     def read_cfg(self):
         parser = RawConfigParser()
         parser.read(self.cfg_file)
         if not parser.has_section('mail'):
-            print 'Creating cfg file.'
+            print('Creating cfg file.')
             self.make_cfg()
         
         self.auth     = parser.get('mail','auth')
@@ -90,7 +93,7 @@ password = Your user password
                  subject='',
                  attach='',
                  body=' '): 
-        print 'Sending email'
+        print('Sending email')
         msg = MIMEMultipart()
         msg["From"]    = self.mailfrom
         msg["To"]      = sendto
@@ -121,24 +124,24 @@ password = Your user password
             try:
                 self._print('Logging into to SMTP: %s %s'%(self.user,self.passwd))
                 server.login(self.user, self.passwd)  # optional
-            except Exception,e:
-                print 'Failed Login %s'%e
+            except Exception as e:
+                print('Failed Login %s'%e)
                 sys.exit(0)
             
         else:
             try:
                 self._print('Connecting to SMTP')
                 server.connect()
-            except Exception,e:
-                print 'Failed to connect %s'%e
+            except Exception as e:
+                print('Failed to connect %s'%e)
                 sys.exit(0)
      
         try:
             self._print('Sending mail to: %s' %sendto)
             server.sendmail(self.mailfrom, sendto, msg.as_string())
-            print 'mail sent.'
+            print('mail sent.')
             server.close()
-        except Exception, e:
+        except Exception as e:
             errorMsg = "Unable to send email. Error: %s" % str(e)
         
 
@@ -165,14 +168,13 @@ if __name__ == "__main__":
                     body=args.message)
     else:
         #try except blocks used do to stash reading EOF on no input
-        sendto = raw_input('Send to: ') or None
+        sendto = input('Send to: ') or None
         if not sendto:
             sys.exit(0)
-        subject = raw_input('Subject: ') or ''
-        msg = raw_input('Message: ') or ''
-        file = raw_input('Attachment: ') or ''
+        subject = input('Subject: ') or ''
+        msg = input('Message: ') or ''
+        file = input('Attachment: ') or ''
         smail.send(sendto=sendto,
                     subject=subject,
                     attach=file,
                     body=msg)
-        

--- a/bin/md5sum.py
+++ b/bin/md5sum.py
@@ -14,12 +14,15 @@ optional arguments:
                md5_hash filename
                etc.
 '''
+from __future__ import print_function
 import argparse
 from Crypto.Hash import MD5
 import re
 import sys
 import os
-import cStringIO
+
+from six import StringIO
+
 
 def get_hash(fileobj):
     h = MD5.new()
@@ -37,14 +40,14 @@ def check_list(fileobj):
         try:
             with open(match.group(2),'rb') as f1:
                 if match.group(1) == get_hash(f1):
-                    print match.group(2)+': Pass'
+                    print(match.group(2)+': Pass')
                 else:
-                    print match.group(2)+': Fail'
+                    print(match.group(2)+': Fail')
         except:
-            print 'Invalid format.'
+            print('Invalid format.')
                 
 def make_file(txt):
-    f = cStringIO.StringIO()
+    f = StringIO()
     f.write(txt)
     f.seek(0)
     return f
@@ -67,10 +70,10 @@ else:
         for arg in args.file:
             if os.path.isfile(arg):
                 with open(arg,'rb') as f:
-                    print get_hash(f)+' '+arg
+                    print(get_hash(f)+' '+arg)
             else:
-                print get_hash(make_file(arg))
+                print(get_hash(make_file(arg)))
     else:
-        print get_hash(make_file(sys.stdin.read()))
+        print(get_hash(make_file(sys.stdin.read())))
         
     

--- a/bin/monkeylord.py
+++ b/bin/monkeylord.py
@@ -1,4 +1,5 @@
 """easiliy manage monkey-patches. See 'man monkeypatching' for more help."""
+from __future__ import print_function
 import argparse
 import sys
 import json

--- a/bin/mount.py
+++ b/bin/mount.py
@@ -1,142 +1,147 @@
 """mount a filesystem."""
+from __future__ import print_function
+
 import argparse
 import sys
 
-from stashutils import mount_manager
+from six import string_types
+from six.moves import input
+
+from stashutils import mount_ctrl, mount_manager
 from stashutils.fsi.interfaces import FILESYSTEM_TYPES
-from stashutils import mount_ctrl
-
-
-_stash = globals()["_stash"]
 
 
 def list_mounts():
-	"""list all mounts"""
-	manager = mount_ctrl.get_manager()
-	if manager is None:
-		manager = mount_manager.MountManager()
-		mount_ctrl.set_manager(manager)
-	
-	mounts = manager.get_mounts()
-	for p, fsi, readonly in mounts:
-		print "{f} on {p}".format(f=fsi.repr(), p=p)
+    """list all mounts"""
+    manager = mount_ctrl.get_manager()
+    if manager is None:
+        manager = mount_manager.MountManager()
+        mount_ctrl.set_manager(manager)
+
+    mounts = manager.get_mounts()
+    for p, fsi, readonly in mounts:
+        print("{f} on {p}".format(f=fsi.repr(), p=p))
+
+
+def main():
+    global _stash
+    if len(sys.argv) == 2 and ("-l" in sys.argv):
+        list_mounts()
+        sys.exit(0)
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-l", "--show-labels", action="store_true", dest="list",
+        help="show also filesystem labels"
+        )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", dest="v",
+        help="be more chatty"
+        )
+    parser.add_argument(
+        "-y", "--yes", action="store_true", dest="yes",
+        help="enable the monkeypatches without asking")
+    parser.add_argument(
+        "-f", "--fake", action="store_false", dest="do_mount",
+        help="dry run; do not mount fs"
+        )
+    parser.add_argument(
+        "-r", "--read-only", action="store_true", dest="readonly",
+        help="mount the filesystem read-only"
+        )
+    parser.add_argument(
+        "-t", "--type", action="store", dest="type", default=None,
+        help="Type of the filesystem to mount"
+        )
+    parser.add_argument(
+        "options", action="store", nargs="*",
+        help="additional arguments for mounting the fs",
+        default=[]
+        )
+    parser.add_argument(
+        "dir", action="store", help="dir to mount to"
+        )
+    ns = parser.parse_args()
+    
+    if ns.type is None:
+        print(_stash.text_color("Error: no FS-Type specified!", "red"))
+        sys.exit(1)
+    
+    manager = mount_ctrl.get_manager()
+    if manager is None:
+        manager = mount_manager.MountManager()
+        mount_ctrl.set_manager(manager)
+    
+    if not manager.check_patches_enabled():
+        if not ns.yes:
+            print(_stash.text_color("WARNING: ", "red"))
+            print(_stash.text_color(
+                "The 'mount'-command needs to enable a few monkeypatches.",
+                "yellow"
+                ))
+            print(_stash.text_color(
+                "Monkeypatches may make the system unstable.", "yellow"
+                ))
+            y = input(
+                _stash.text_color(
+                    "Do you want to enable these patches? (y/n)", "yellow"
+                    )
+                ).upper() == "Y"
+            
+            if not y:
+                print(_stash.text_color(
+                    "Error: Monkeypatches not enabled!", "red"
+                    ))
+                sys.exit(1)
+            manager.enable_patches()
+        else:
+            manager.enable_patches()
+    
+    if not ns.type in FILESYSTEM_TYPES:
+        print(_stash.text_color(
+            "Error: Unknown Filesystem-Type!", "red"
+            ))
+        sys.exit(1)
+    
+    fsic = FILESYSTEM_TYPES[ns.type]
+    if ns.v:
+        logger = sys.stdout.write
+        print("Creating FSI...")
+    else:
+        logger = None
+    fsi = fsic(logger=logger)
+    if ns.v:
+        print("Connecting FSI...")
+    msg = fsi.connect(*tuple(ns.options))
+    if isinstance(msg, string_types):
+        print(_stash.text_color(
+            "Error: {m}".format(m=msg), "red"
+            ))
+        sys.exit(1)
+    if ns.do_mount:
+        try:
+            manager.mount_fsi(ns.dir, fsi, readonly=ns.readonly)
+        except mount_manager.MountError as e:
+            print(_stash.text_color("Error: {e}".format(e=e.message), "red"))
+            try:
+                if ns.v:
+                    print("unmounting FSI...")
+                fsi.close()
+            except Exception as e:
+                print(_stash.text_color(
+                    "Error unmounting FSI: {e}".format(e=e.message), "red"
+                    ))
+            else:
+                if ns.v:
+                    print("Finished cleanup.")
+            sys.exit(1)
+    else:
+        # close fs
+        fsi.close()
+    if ns.v:
+        print("Done.")
+    if ns.list:
+        list_mounts()
 
 
 if __name__ == "__main__":
-	if len(sys.argv) == 2 and ("-l" in sys.argv):
-		list_mounts()
-		sys.exit(0)
-	parser = argparse.ArgumentParser()
-	parser.add_argument(
-		"-l", "--show-labels", action="store_true", dest="list",
-		help="show also filesystem labels"
-		)
-	parser.add_argument(
-		"-v", "--verbose", action="store_true", dest="v",
-		help="be more chatty"
-		)
-	parser.add_argument(
-		"-y", "--yes", action="store_true", dest="yes",
-		help="enable the monkeypatches without asking")
-	parser.add_argument(
-		"-f", "--fake", action="store_false", dest="do_mount",
-		help="dry run; do not mount fs"
-		)
-	parser.add_argument(
-		"-r", "--read-only", action="store_true", dest="readonly",
-		help="mount the filesystem read-only"
-		)
-	parser.add_argument(
-		"-t", "--type", action="store", dest="type", default=None,
-		help="Type of the filesystem to mount"
-		)
-	parser.add_argument(
-		"options", action="store", nargs="*",
-		help="additional arguments for mounting the fs",
-		default=[]
-		)
-	parser.add_argument(
-		"dir", action="store", help="dir to mount to"
-		)
-	ns = parser.parse_args()
-	
-	if ns.type is None:
-		print _stash.text_color("Error: no FS-Type specified!", "red")
-		sys.exit(1)
-	
-	manager = mount_ctrl.get_manager()
-	if manager is None:
-		manager = mount_manager.MountManager()
-		mount_ctrl.set_manager(manager)
-	
-	if not manager.check_patches_enabled():
-		if not ns.yes:
-			print _stash.text_color("WARNING: ", "red")
-			print _stash.text_color(
-				"The 'mount'-command needs to enable a few monkeypatches.",
-				"yellow"
-				)
-			print _stash.text_color(
-				"Monkeypatches may make the system unstable.", "yellow"
-				)
-			y = raw_input(
-				_stash.text_color(
-					"Do you want to enable these patches? (y/n)", "yellow"
-					)
-				).upper() == "Y"
-			
-			if not y:
-				print _stash.text_color(
-					"Error: Monkeypatches not enabled!", "red"
-					)
-				sys.exit(1)
-			manager.enable_patches()
-		else:
-			manager.enable_patches()
-	
-	if not ns.type in FILESYSTEM_TYPES:
-		print _stash.text_color(
-			"Error: Unknown Filesystem-Type!", "red"
-			)
-		sys.exit(1)
-	
-	fsic = FILESYSTEM_TYPES[ns.type]
-	if ns.v:
-		logger = sys.stdout.write
-		print "Creating FSI..."
-	else:
-		logger = None
-	fsi = fsic(logger=logger)
-	if ns.v:
-		print "Connecting FSI..."
-	msg = fsi.connect(*tuple(ns.options))
-	if isinstance(msg, (str, unicode)):
-		print _stash.text_color(
-			"Error: {m}".format(m=msg), "red"
-			)
-		sys.exit(1)
-	if ns.do_mount:
-		try:
-			manager.mount_fsi(ns.dir, fsi, readonly=ns.readonly)
-		except mount_manager.MountError as e:
-			print _stash.text_color("Error: {e}".format(e=e.message), "red")
-			try:
-				if ns.v:
-					print "unmounting FSI..."
-				fsi.close()
-			except Exception as e:
-				print _stash.text_color(
-					"Error unmounting FSI: {e}".format(e=e.message), "red"
-					)
-			else:
-				if ns.v:
-					print "Finished cleanup."
-			sys.exit(1)
-	else:
-		# close fs
-		fsi.close()
-	if ns.v:
-		print "Done."
-	
-	if ns.list:
-		list_mounts()
+    main()

--- a/bin/pip.py
+++ b/bin/pip.py
@@ -17,24 +17,24 @@ List of sub-commands:
         remove      removed an installed package
         update      update an installed package
 """
-import sys
-import os
-import ast
-import shutil
-import types
-import contextlib
-import requests
-import re
-import operator
+from __future__ import print_function
 
-import six
+import ast
+import contextlib
+import operator
+import os
+import re
+import shutil
+import sys
+import types
 from distutils.util import convert_path
 from fnmatch import fnmatchcase
-# noinspection PyUnresolvedReferences
-from six.moves import filterfalse
+
+import requests
+import six
+from six.moves.configparser import NoSectionError, SafeConfigParser
 
 from stashutils.extensions import create_command
-
 
 PYTHONISTA_BUNDLED_MODULES = [
     'bottle', 'beautifulsoup4', 'pycrypto', 'py-dateutil',
@@ -109,7 +109,7 @@ class PackageFinder(object):
         includes = cls._build_filter(*include)
         excludes = cls._build_filter('ez_setup', '*__pycache__', *exclude)
         out = filter(includes, out)
-        out = filterfalse(excludes, out)
+        out = six.moves.filterfalse(excludes, out)
         return list(out)
 
     @staticmethod
@@ -137,7 +137,7 @@ class PackageFinder(object):
         for root, dirs, files in os.walk(base_path, followlinks=True):
             # Exclude directories that contain a period, as they cannot be
             #  packages. Mutate the list to avoid traversal.
-            dirs[:] = filterfalse(has_dot, dirs)
+            dirs[:] = six.moves.filterfalse(has_dot, dirs)
             for dir in dirs:
                 yield os.path.relpath(os.path.join(root, dir), base_path)
 
@@ -314,8 +314,6 @@ def save_current_sys_modules():
         sys.modules[k] = v
 
 
-# noinspection PyUnresolvedReferences
-from six.moves.configparser import SafeConfigParser, NoSectionError
 
 
 class CIConfigParer(SafeConfigParser):
@@ -677,7 +675,7 @@ class ArchiveFileInstaller(object):
 
         # handle entry points
         entry_points = kwargs.get("entry_points", {})
-        if isinstance(entry_points, (str, unicode)):
+        if isinstance(entry_points, six.string_types):
             if pkg_resources is not None:
                 entry_points = {s: c for s, c in pkg_resources.split_sections(entry_points)}
             else:
@@ -685,7 +683,7 @@ class ArchiveFileInstaller(object):
                 entry_points = {}
         for epn in entry_points:
             ep = entry_points[epn]
-            if isinstance(ep, (str, unicode)):
+            if isinstance(ep, six.string_types):
                 ep = [ep]
             if epn == "console_scripts":
                 for dec in ep:

--- a/bin/python.py
+++ b/bin/python.py
@@ -11,6 +11,7 @@ usage:
     python -c command
     python python_file.py [args]
 """
+from __future__ import print_function
 
 import runpy
 import sys
@@ -57,7 +58,7 @@ if ns.module:
     sys.exit(0)
 
 elif ns.cmd:
-    exec ns.cmd
+    exec(ns.cmd)
     sys.exit(0)
 
 else:

--- a/bin/rm.py
+++ b/bin/rm.py
@@ -14,11 +14,15 @@ optional arguments:
                      permission or file existence (override -i)
   -v, --verbose      explain what is being done
 """
+from __future__ import print_function
 
 import os
 import sys
 import shutil
 from argparse import ArgumentParser
+
+from six.moves import input
+
 
 def main(args):
     ap = ArgumentParser()
@@ -45,14 +49,14 @@ def main(args):
     #setup print function
     if ns.verbose:
         def printp(text):
-            print text
+            print(text)
     else:
         def printp(text):
             pass
 
     if ns.interactive and not ns.force:
         def prompt(file):
-            result = raw_input('Delete %s? [Y,n]: ' % file)
+            result = input('Delete %s? [Y,n]: ' % file)
             if result == 'Y' or result == 'y':
                 return True
             else:
@@ -69,7 +73,7 @@ def main(args):
                     printp('%s has been deleted' % path)
                 except:
                     if not ns.force:
-                        print '%s: unable to remove' % path
+                        print('%s: unable to remove' % path)
 
         elif os.path.isdir(path) and ns.recursive:
             if prompt(path):
@@ -78,13 +82,13 @@ def main(args):
                     printp('%s has been deleted' % path)
                 except:
                     if not ns.force:
-                        print '%s: unable to remove' % path
+                        print('%s: unable to remove' % path)
 
         elif os.path.isdir(path):
-            print '%s: is a directory' % path
+            print('%s: is a directory' % path)
         else:
             if not ns.force:
-                print '%s: does not exist' % path
+                print('%s: does not exist' % path)
 
 
 if __name__ == '__main__':

--- a/bin/scp.py
+++ b/bin/scp.py
@@ -7,26 +7,30 @@ usage:
 
     PUT
     scp [file/dir] [file/dir] [user@host:dir]
-"""
 
-import argparse
-# scp.py
-# Copyright (C) 2008 James Bardin <j.bardin@gmail.com>
-
-"""
 Created by jbardin
 https://github.com/jbardin/scp.py
 Utilities for sending files over ssh using the scp1 protocol.
 """
 
-__version__ = '0.8.0'
+# scp.py
+# Copyright (C) 2008 James Bardin <j.bardin@gmail.com>
 
+from __future__ import print_function
+
+import argparse
 import locale
 import os
-import sys
 import re
-from socket import timeout as SocketTimeout
+import sys
 from distutils.version import StrictVersion
+from socket import timeout as SocketTimeout
+
+from six.moves import input
+
+import paramiko
+
+__version__ = '0.8.0'
 
 
 def install_module_from_github(username, package_name, version):
@@ -49,11 +53,10 @@ def install_module_from_github(username, package_name, version):
     globals()['_stash'](cmd_string)
 
 
-import paramiko
 if StrictVersion(paramiko.__version__) < StrictVersion('1.15'):
     # Install paramiko 1.16.0 to fix a bug with version < 1.15
     install_module_from_github('paramiko', 'paramiko', 'v1.16.0')
-    print 'Please restart Pythonista for changes to take full effect'
+    print('Please restart Pythonista for changes to take full effect')
     sys.exit(0)
 
 
@@ -513,7 +516,7 @@ def parse_host(arg):
 
 def scp_callback(filename, size, sent):
     if size == sent:
-        print filename
+        print(filename)
     
 
 if __name__ == '__main__':
@@ -548,7 +551,7 @@ if __name__ == '__main__':
 
     else:
         if len(key_filename) == 0:  # no key file found
-            password = raw_input('Enter passsword:')
+            password = input('Enter passsword:')
             ssh.connect(host, username=user, password=password, port=args.port)
         else:
             ssh.connect(host, username=user, key_filename=key_filename, port=args.port)
@@ -558,14 +561,11 @@ if __name__ == '__main__':
 
     #scp.put('stash',remote_path='stash/',recursive=True)
     if scp_mode:
-        print 'Copying from server...'
+        print('Copying from server...')
         scp.get(host_path, local_path=files[0], recursive=True)
         
     else:
-        print 'Copying to server...'
+        print('Copying to server...')
         scp.put(files, recursive=True, remote_path=host_path)
 
     ssh.close()
-
-
-

--- a/bin/selfupdate.py
+++ b/bin/selfupdate.py
@@ -9,6 +9,7 @@ Usage: selfupdate.py [-n] [-f] [target]
        -n, --check    check for update only
        -f, --force    update without checking for new version
 """
+from __future__ import print_function
 import os
 import sys
 import requests
@@ -99,7 +100,7 @@ def main(args):
 
         except UpdateError as e:
             has_update = False  # do not update in case of errors
-            print(_stash.text_color('Error: %s' % e.message, 'red'))
+            print(_stash.text_color('Error: %s' % e.args[0], 'red'))
 
     # Perform update if new version is available and not just checking only
     if not ns.check and has_update:
@@ -108,9 +109,9 @@ def main(args):
                            _stash.text_style(url, {'color': 'blue', 'traits': ['underline']})))
 
         try:
-            exec requests.get(
+            exec(requests.get(
                 '{}?q={}'.format(url, randint(1, 999999))
-            ).text in {'_IS_UPDATE': True, '_br': branch, '_owner': owner}
+            ).text, {'_IS_UPDATE': True, '_br': branch, '_owner': owner})
             print(_stash.text_color('Update completed.', 'green'))
             print(_stash.text_color(
                 'Please restart Pythonista to ensure changes becoming effective.', 'green'))

--- a/bin/sha1sum.py
+++ b/bin/sha1sum.py
@@ -14,12 +14,13 @@ optional arguments:
                sha1_hash filename
                etc.
 '''
+from __future__ import print_function
 import argparse
 from Crypto.Hash import SHA
 import re
 import sys
 import os
-import cStringIO
+from six import StringIO
 
 def get_hash(fileobj):
     h = SHA.new()
@@ -37,14 +38,14 @@ def check_list(fileobj):
         try:
             with open(match.group(2),'rb') as f1:
                 if match.group(1) == get_hash(f1):
-                    print match.group(2)+': Pass'
+                    print(match.group(2)+': Pass')
                 else:
-                    print match.group(2)+': Fail'
+                    print(match.group(2)+': Fail')
         except:
-            print 'Invalid format.'
+            print('Invalid format.')
                 
 def make_file(txt):
-    f = cStringIO.StringIO()
+    f = StringIO()
     f.write(txt)
     f.seek(0)
     return f
@@ -67,10 +68,10 @@ else:
         for arg in args.file:
             if os.path.isfile(arg):
                 with open(arg,'rb') as f:
-                    print get_hash(f)+' '+arg
+                    print(get_hash(f)+' '+arg)
             else:
-                print get_hash(make_file(arg))
+                print(get_hash(make_file(arg)))
     else:
-        print get_hash(make_file(sys.stdin.read()))
+        print(get_hash(make_file(sys.stdin.read())))
         
     

--- a/bin/sha256sum.py
+++ b/bin/sha256sum.py
@@ -14,12 +14,17 @@ optional arguments:
                sha256_hash filename
                etc.
 '''
+from __future__ import print_function
+
 import argparse
-from Crypto.Hash import SHA256
+import os
 import re
 import sys
-import os
-import cStringIO
+
+from six import StringIO
+
+from Crypto.Hash import SHA256
+
 
 def get_hash(fileobj):
     h = SHA256.new()
@@ -37,14 +42,14 @@ def check_list(fileobj):
         try:
             with open(match.group(2),'rb') as f1:
                 if match.group(1) == get_hash(f1):
-                    print match.group(2)+': Pass'
+                    print(match.group(2)+': Pass')
                 else:
-                    print match.group(2)+': Fail'
+                    print(match.group(2)+': Fail')
         except:
-            print 'Invalid format.'
+            print('Invalid format.')
                 
 def make_file(txt):
-    f = cStringIO.StringIO()
+    f = StringIO()
     f.write(txt)
     f.seek(0)
     return f
@@ -67,10 +72,8 @@ else:
         for arg in args.file:
             if os.path.isfile(arg):
                 with open(arg,'rb') as f:
-                    print get_hash(f)+' '+arg
+                    print(get_hash(f)+' '+arg)
             else:
-                print get_hash(make_file(arg))
+                print(get_hash(make_file(arg)))
     else:
-        print get_hash(make_file(sys.stdin.read()))
-        
-    
+        print(get_hash(make_file(sys.stdin.read())))

--- a/bin/sort.py
+++ b/bin/sort.py
@@ -1,4 +1,5 @@
 """Sort standard input or given files to standard output"""
+from __future__ import print_function
 import os
 import sys
 import fileinput
@@ -18,7 +19,7 @@ def main(args):
             lines = sorted(lines)
             if ns.reverse:
                 lines = lines[::-1]
-            print ''.join(lines)
+            print(''.join(lines))
 
     fileinput.close()  # in case it is not closed
     try:

--- a/bin/source.py
+++ b/bin/source.py
@@ -10,6 +10,7 @@ positional arguments:
 optional arguments:
   -h, --help  show this help message and exit
 """
+from __future__ import print_function
 
 import sys
 from argparse import ArgumentParser
@@ -32,9 +33,9 @@ def main(args):
             _stash(ins.readlines(), persistent_level=1)
 
     except IOError as e:
-        print '%s: %s' % (e.filename, e.strerror)
+        print('%s: %s' % (e.filename, e.strerror))
     except Exception as e:
-        print 'error: %s' % str(e)
+        print('error: %s' % str(e))
     finally:
         pass
 

--- a/bin/sqlite.py
+++ b/bin/sqlite.py
@@ -5,6 +5,7 @@ Created by: Chris Houser (Briarfox)
 Use sqlite ?file? to open a database in the shell.
 You can pass params to run one command. ex. sqlite test.db .dump > test.sql
 '''
+from __future__ import print_function
 import sqlite3
 import os
 import cmd
@@ -27,14 +28,14 @@ class SqliteCMD(cmd.Cmd):
         self.output = sys.stdout
 
     def preloop(self):
-        print 'sqlite3 version %s' % sqlite3.sqlite_version
-        print '.(dot) is used for all none sql commands.'
-        print 'Use .help for non sqlite command list'
-        print 'All sql commands must end with ;'
+        print('sqlite3 version %s' % sqlite3.sqlite_version)
+        print('.(dot) is used for all none sql commands.')
+        print('Use .help for non sqlite command list')
+        print('All sql commands must end with ;')
         if self.database == ':memory:':
-            print 'Using database :memory:\nuse .open ?file? to open a database'
+            print('Using database :memory:\nuse .open ?file? to open a database')
         else:
-            print 'Using databasse: %s' % self.database
+            print('Using databasse: %s' % self.database)
 
     def do_exit(self,*args):
         '''Exit shell'''
@@ -57,7 +58,7 @@ class SqliteCMD(cmd.Cmd):
 
     def display(self, line):
         if self.output == sys.stdout:
-            print line
+            print(line)
         else:
             with open(self.output, 'a+') as f:
                 f.write(line+'\n')
@@ -99,7 +100,7 @@ If table is specified, dump that table.
                 cu.execute("detach database attached_db")
                 self.display("\n".join(conn.iterdump()))
         except:
-            print 'Invalid table specified'
+            print('Invalid table specified')
 
     def do_backup(self, line):
         '''.backup ?DB? FILE      
@@ -116,11 +117,11 @@ Clone data into NEWDB from the existing database'''
                 conn = sqlite3.connect(line)
                 cur = conn.cursor()
                 cur.executescript('\n'.join(self.conn.iterdump()))
-                print "Switched to database: %s" % line
+                print("Switched to database: %s" % line)
                 self.conn = conn
                 self.cur = cur
-            except sqlite3.Error, e:
-                print 'There was an error with the clone %s' % e.args[0]
+            except sqlite3.Error as e:
+                print('There was an error with the clone %s' % e.args[0])
 
     def do_open(self, line):
         ''' .open ?FILENAME?       
@@ -202,9 +203,9 @@ List names of tables
                 self.conn.commit()
                 if rtn.lstrip().upper().startswith('SELECT') or rtn.lstrip().upper().startswith('PRAGMA'):
                     self.format_print(self.cur.fetchall())
-        except sqlite3.Error, e:
-            print e
-            print 'An Error occured:', e.args[0]
+        except sqlite3.Error as e:
+            print(e)
+            print('An Error occured:', e.args[0])
 
     def do_EOF(self, line):
         return True

--- a/bin/ssh-keygen.py
+++ b/bin/ssh-keygen.py
@@ -9,6 +9,7 @@ usage:
     [-N] - password default:None
     [-f] - output file name. default: id_ssh_key
 """
+from __future__ import print_function
 import os
 import sys
 import argparse
@@ -54,11 +55,11 @@ def main(args):
                 k.write_private_key_file(filepath, password=ns.password)
                 with open(filepath + '.pub', 'w') as outs:
                     outs.write('ssh-' + key_mode[ns.type] + ' ' + k.get_base64())
-            print 'ssh keys generated with %s encryption' % ns.type
+            print('ssh keys generated with %s encryption' % ns.type)
         else:
-            print 'Keys not generated'
-    except Exception, e:
-        print e
+            print('Keys not generated')
+    except Exception as e:
+        print(e)
 
 
 if __name__ == '__main__':

--- a/bin/ssh.py
+++ b/bin/ssh.py
@@ -18,12 +18,15 @@ optional arguments:
   --password PASSWORD   Password for rsa/dsa key or password login
   -p PORT, --port PORT  port for ssh default: 22
 """
+from __future__ import print_function
 
 import sys
 import os
 import argparse
 import threading
 from distutils.version import StrictVersion
+
+from six.moves import input
 
 _SYS_STDOUT = sys.__stdout__
 
@@ -45,7 +48,7 @@ import paramiko
 if StrictVersion(paramiko.__version__) < StrictVersion('1.15'):
     # Install paramiko 1.16.0 to fix a bug with version < 1.15
     _stash('pip install paramiko==1.16.0')
-    print 'Please restart Pythonista for changes to take full effect'
+    print('Please restart Pythonista for changes to take full effect')
     sys.exit(0)
 
 
@@ -71,14 +74,14 @@ class StashSSH(object):
         self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
     def connect(self, host, passwd=None, port=22):
-        print 'Connecting...'
+        print('Connecting...')
         username, host = host.split('@')
 
         if passwd is not None:
             return self._connect_with_passwd(host, username, passwd, port)
 
         else:
-            print 'Looking for SSH keys...'
+            print('Looking for SSH keys...')
             key_filename = self.find_ssh_keys()
             if len(key_filename) > 0:
                 try:
@@ -89,17 +92,17 @@ class StashSSH(object):
                                         key_filename=key_filename)
                     return True
                 except paramiko.SSHException as e:
-                    print 'Failed to login with SSH Keys: {}'.format(repr(e))
-                    print 'Trying password ...'
-                    passwd = raw_input('Enter password:')
+                    print('Failed to login with SSH Keys: {}'.format(repr(e)))
+                    print('Trying password ...')
+                    passwd = input('Enter password:')
                     return self._connect_with_passwd(host, username, passwd, port)
 
                 except Exception as e:
-                    print 'Error: {}'.format(e)
+                    print('Error: {}'.format(e))
                     return False
             else:
-                print 'No SSH key found. Trying password ...'
-                passwd = raw_input('Enter password:')
+                print('No SSH key found. Trying password ...')
+                passwd = input('Enter password:')
                 return self._connect_with_passwd(host, username, passwd, port)
 
     def _connect_with_passwd(self, host, username, passwd, port):
@@ -110,7 +113,7 @@ class StashSSH(object):
                                 port=port)
             return True
         except Exception as e:
-            print 'Error: {}'.format(e)
+            print('Error: {}'.format(e))
             return False
 
     def find_ssh_keys(self):
@@ -140,8 +143,8 @@ class StashSSH(object):
 
     def single_exec(self, command):
         sin, sout, serr = self.client.exec_command(command)
-        print sout.read()
-        print serr.read()
+        print(sout.read())
+        print(serr.read())
         self.client.close()
 
     def interactive(self):
@@ -154,7 +157,7 @@ class StashSSH(object):
         t1.join()
         self.chan.close()
         self.client.close()
-        print '\nconnection closed\n'
+        print('\nconnection closed\n')
 
 
 CTRL_KEY_FLAG = (1 << 18)
@@ -289,7 +292,7 @@ if __name__ == '__main__':
     sv_delegate = SshSVDelegate(ssh)
 
     if ssh.connect(host=args.host, passwd=args.password, port=args.port):
-        print 'Connected'
+        print('Connected')
         if args.command:
             ssh.single_exec(args.command)
         else:
@@ -300,4 +303,4 @@ if __name__ == '__main__':
                                                  sv_responder=sv_delegate):
                 ssh.interactive()
     else:
-        print 'Unable to connect'
+        print('Unable to connect')

--- a/bin/stashconf.py
+++ b/bin/stashconf.py
@@ -1,4 +1,5 @@
 """ List and set StaSh configuration options """
+from __future__ import print_function
 
 import sys
 import argparse
@@ -22,19 +23,19 @@ def main(args):
 
     if ns.list:
         for name in sorted(config.keys()):
-            print '%s=%s' % (name, config[name].__dict__[name])
+            print('%s=%s' % (name, config[name].__dict__[name]))
 
     else:
         try:
             if ns.name is not None and ns.value is not None:
                 config[ns.name].__dict__[ns.name] = ns.value
             elif ns.name is not None:
-                print '%s=%s' % (ns.name, config[ns.name].__dict__[ns.name])
+                print('%s=%s' % (ns.name, config[ns.name].__dict__[ns.name]))
             else:
                 ap.print_help()
 
         except KeyError:
-            print '%s: invalid config option name' % ns.name
+            print('%s: invalid config option name' % ns.name)
             sys.exit(1)
 
 

--- a/bin/tar.py
+++ b/bin/tar.py
@@ -30,13 +30,14 @@ optional arguments:
   -x, --extract         Extract an archive.
   -f FILE, --file FILE  Archive filename.
 '''
+from __future__ import print_function
 import argparse
 import os
 import tarfile
 
 def output_print(msg):
     if args.verbose:
-        print msg
+        print(msg)
         
 class MyFileObject(tarfile.ExFileObject):
     def read(self, size, *args):
@@ -70,7 +71,7 @@ def extract_all(filename,members=None, directory=''):
     else:
         tar.extractall(path=directory)
     tar.close()
-    print 'Archive extracted.'
+    print('Archive extracted.')
     
     
 def create_tar(filename,files):
@@ -93,7 +94,7 @@ def create_tar(filename,files):
         output_print('Adding %s' % name)
         tar.add(name, filter=tar_filter)
     tar.close()
-    print 'Archive Created.' 
+    print('Archive Created.') 
     
 def list_tar(filename):
     if args.gzip:

--- a/bin/telnet.py
+++ b/bin/telnet.py
@@ -4,20 +4,24 @@ Simple telent client.
 
 usage: telnet host [-p port] [--timeout N]
 """
-import sys
-import select
+from __future__ import print_function
+
 import argparse
+import select
+import sys
 import telnetlib
 import threading
 
-_SYS_STDOUT = sys.__stdout__
+from six import text_type
 
 try:
     import ui
 except ImportError:
     import dummyui as ui
 
+_SYS_STDOUT = sys.__stdout__
 _stash = globals()['_stash']
+
 """:type : StaSh"""
 
 try:
@@ -33,9 +37,8 @@ class StashTelnet(object):
 
     def __init__(self):
         # Initialize the pyte screen based on the current screen size
-        font_width, font_height = ui.measure_string(
-            'a',
-            font=('Menlo-Regular', _stash.config.getint('display', 'TEXT_FONT_SIZE')))
+        font = ('Menlo-Regular', _stash.config.getint('display', 'TEXT_FONT_SIZE'))
+        font_width, font_height = ui.measure_string('a', font=font)
         # noinspection PyUnresolvedReferences
         self.screen = pyte.screens.DiffScreen(
             int(_stash.ui.width / font_width),
@@ -47,7 +50,7 @@ class StashTelnet(object):
         self.client = None
 
     def connect(self, host, port=23, timeout=2):
-        print 'Connecting...'
+        print('Connecting...')
         try:
             self.client = telnetlib.Telnet(host, port, timeout)
             return True
@@ -83,7 +86,7 @@ class StashTelnet(object):
         t1.start()
         t1.join()
         self.client.close()
-        print '\nconnection closed\n'
+        print('\nconnection closed\n')
 
 
 CTRL_KEY_FLAG = (1 << 18)
@@ -97,7 +100,7 @@ class SshUserActionDelegate(object):
         self.telnet = telnet
 
     def send(self, s):
-        self.telnet.stream.feed(s if isinstance(s, unicode) else s.decode('utf-8'))
+        self.telnet.stream.feed(s if isinstance(s, text_type) else s.decode('utf-8'))
         self.telnet.client.write(s.encode('utf-8'))
 
 
@@ -212,7 +215,7 @@ if __name__ == '__main__':
     sv_delegate = SshSVDelegate(telnet)
 
     if telnet.connect(host=args.host, port=args.port, timeout=args.timeout):
-        print 'Connected. Press Ctrl-C to quit.'
+        print('Connected. Press Ctrl-C to quit.')
         _stash.stream.feed(u'\u009bc', render_it=False)
         with _stash.user_action_proxy.config(tv_responder=tv_vk_kc_delegate,
                                              kc_responder=tv_vk_kc_delegate.kc_pressed,
@@ -220,4 +223,4 @@ if __name__ == '__main__':
                                              sv_responder=sv_delegate):
             telnet.interactive()
     else:
-        print 'Unable to connect'
+        print('Unable to connect')

--- a/bin/totd.py
+++ b/bin/totd.py
@@ -1,5 +1,6 @@
 """ Tip of the day
 """
+from __future__ import print_function
 import os
 import sys
 import json
@@ -24,11 +25,11 @@ def main(args):
         tips = json.load(ins)
 
         if ns.count:
-            print 'Total available tips: %s' % len(tips)
+            print('Total available tips: %s' % len(tips))
         else:
             idx = random.randint(0, len(tips) - 1)
-            print '%s: %s' % (_stash.text_bold('Tip'),
-                              _stash.text_italic(tips[idx]))
+            print('%s: %s' % (_stash.text_bold('Tip'),
+                              _stash.text_italic(tips[idx])))
 
 
 if __name__ == '__main__':

--- a/bin/umount.py
+++ b/bin/umount.py
@@ -1,4 +1,5 @@
 """unmount a filesystem."""
+from __future__ import print_function
 import argparse
 import sys
 
@@ -29,9 +30,9 @@ if __name__ == "__main__":
 	ns = parser.parse_args()
 	
 	if not (ns.directory or ("-a" in sys.argv) or ("--all" in sys.argv)):
-		print _stash.text_color(
+		print(_stash.text_color(
 			"Error: no target directory specified!", "red"
-			)
+			))
 		sys.exit(1)
 	
 	manager = mount_ctrl.get_manager()
@@ -49,14 +50,14 @@ if __name__ == "__main__":
 	
 	for path in to_unmount:
 		if ns.v:
-			print "Unmounting '{p}'...".format(p=path)
+			print("Unmounting '{p}'...".format(p=path))
 		try:
 			manager.unmount_fsi(path, force=ns.force)
 		except mount_manager.MountError as e:
 			exitcode = 1
-			print _stash.text_color(
+			print(_stash.text_color(
 				"Error: {e}".format(e=e.message), "red"
-				)
+				))
 	if ns.v:
-		print "Done."
+		print("Done.")
 	sys.exit(exitcode)

--- a/bin/uniq.py
+++ b/bin/uniq.py
@@ -1,4 +1,5 @@
 """Print standard input or files, omitting repeated lines"""
+from __future__ import print_function
 
 import os
 import sys
@@ -12,7 +13,7 @@ def main(args):
 
     def _print(lines):
         if lines is not None:
-            print ''.join(lines)
+            print(''.join(lines))
 
     fileinput.close()  # in case it is not closed
     try:

--- a/bin/unzip.py
+++ b/bin/unzip.py
@@ -1,4 +1,5 @@
 """Extract a zip archive into a directory."""
+from __future__ import print_function
 import os
 import sys
 import zipfile
@@ -19,7 +20,7 @@ def main(args):
     ns = ap.parse_args(args)
 
     if not os.path.isfile(ns.zipfile):
-        print "%s: No such file" % ns.zipfile
+        print("%s: No such file" % ns.zipfile)
 
     else:
         # PK magic marker check
@@ -30,7 +31,7 @@ def main(args):
                 pk_check = ''
 
         if pk_check != 'PK':
-            print "%s: does not appear to be a zip file" % ns.zipfile
+            print("%s: does not appear to be a zip file" % ns.zipfile)
             sys.exit(1)
 
         if ns.list:
@@ -43,7 +44,7 @@ def main(args):
             altpath = os.path.join(os.path.dirname(ns.zipfile), altpath)
             location = ns.exdir or altpath
             if (os.path.exists(location)) and not (os.path.isdir(location)):
-                print "%s: destination is not a directory" % location
+                print("%s: destination is not a directory" % location)
                 sys.exit(1)
             elif not os.path.exists(location):
                 os.makedirs(location)
@@ -84,9 +85,9 @@ def main(args):
                             fp.close()
 
                     if ns.verbose or ns.list:
-                        print fn
+                        print(fn)
             except:
-                print "%s: zip file is corrupt" % ns.zipfile
+                print("%s: zip file is corrupt" % ns.zipfile)
 
 
 if __name__ == '__main__':

--- a/bin/version.py
+++ b/bin/version.py
@@ -1,5 +1,6 @@
 """ Show information about this StaSh installation.
 """
+from __future__ import print_function
 
 import os
 import sys
@@ -25,21 +26,21 @@ def ios_version():  # 9.2 (64-bit iPad5,4)
 
 def main():
     STASH_ROOT = os.environ['STASH_ROOT']
-    print _stash.text_style('StaSh v%s' % globals()['_stash'].__version__,
-                            {'color': 'blue', 'traits': ['bold']})
-    print u'%s %s' % (_stash.text_bold('Pythonista'),
-                      pythonista_version())
-    print u'%s %s' % (_stash.text_bold('iOS'),
-                      ios_version())
-    print u'%s: %s' % (_stash.text_bold('root'), collapseuser(STASH_ROOT))
+    print(_stash.text_style('StaSh v%s' % globals()['_stash'].__version__,
+                            {'color': 'blue', 'traits': ['bold']}))
+    print(u'%s %s' % (_stash.text_bold('Pythonista'),
+                      pythonista_version()))
+    print(u'%s %s' % (_stash.text_bold('iOS'),
+                      ios_version()))
+    print(u'%s: %s' % (_stash.text_bold('root'), collapseuser(STASH_ROOT)))
     _stat = os.stat(os.path.join(STASH_ROOT, 'stash.py'))
     last_modified = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(_stat.st_mtime))
-    print u'%s: %s' % (_stash.text_bold('stash.py'), last_modified)
-    print u'%s: %s' % (_stash.text_bold('SELFUPDATE_BRANCH'),
-                       os.environ['SELFUPDATE_BRANCH'])
-    print _stash.text_bold('BIN_PATH:')
+    print(u'%s: %s' % (_stash.text_bold('stash.py'), last_modified))
+    print(u'%s: %s' % (_stash.text_bold('SELFUPDATE_BRANCH'),
+                       os.environ['SELFUPDATE_BRANCH']))
+    print(_stash.text_bold('BIN_PATH:'))
     for p in os.environ['BIN_PATH'].split(':'):
-        print '  %s' % collapseuser(p)
+        print('  %s' % collapseuser(p))
 
 
 if __name__ == '__main__':

--- a/bin/wc.py
+++ b/bin/wc.py
@@ -1,6 +1,7 @@
 """ Print newline, word, and byte counts for each FILE, and a total line if
 more than one FILE is specified.
 """
+from __future__ import print_function
 import os
 import sys
 import argparse
@@ -19,10 +20,10 @@ def main(args):
 
     if ns.lines:
         def _print_res(res):
-            print '%6d %s' % (res[0], res[-1])
+            print('%6d %s' % (res[0], res[-1]))
     else:
         def _print_res(res):
-            print '%6d %8d %8d %s' % res
+            print('%6d %8d %8d %s' % res)
 
     results = []
     nl_count = 0
@@ -35,7 +36,7 @@ def main(args):
 
         if infields[0] is None:
             _, filename, e = infields
-            print '%s: %s' % (filename, repr(e))
+            print('%s: %s' % (filename, repr(e)))
             filename_old = None
         else:
             line, filename, lineno = infields

--- a/bin/wget.py
+++ b/bin/wget.py
@@ -1,14 +1,16 @@
 """ Download a file from a url.
 """
+from __future__ import print_function
 
-import sys
-import urllib2
 import argparse
+import sys
+
+from six.moves.urllib.request import urlopen
 
 try:
     import clipboard
     import console
-except:
+except ImportError:
     import dummyconsole as console
 
 
@@ -24,8 +26,8 @@ def main(args):
     console.show_activity()
     try:
 
-        print 'Opening: %s' % url
-        u = urllib2.urlopen(url)
+        print('Opening: %s' % url)
+        u = urlopen(url)
 
         meta = u.info()
         try:
@@ -33,8 +35,8 @@ def main(args):
         except IndexError:
             file_size = 0
 
-        print "Save as: %s " % output_file,
-        print "(%s bytes)" % file_size if file_size else ""
+        print("Save as: %s " % output_file, end=' ')
+        print("(%s bytes)" % file_size if file_size else "")
 
         with open(output_file, 'wb') as f:
             file_size_dl = 0
@@ -49,11 +51,11 @@ def main(args):
                     status = r"%10d  [%3.2f%%]" % (file_size_dl, file_size_dl * 100. / file_size)
                 else:
                     status = "%10d" % file_size_dl
-                print '\r' + status,
-            print
+                print('\r' + status, end=' ')
+            print()
 
     except:
-        print 'invalid url: %s' % url
+        print('invalid url: %s' % url)
         sys.exit(1)
 
     finally:

--- a/bin/whatis.py
+++ b/bin/whatis.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #by Siddharth Dushantha
 #31 July 2017
 from sys import argv

--- a/bin/which.py
+++ b/bin/which.py
@@ -1,5 +1,6 @@
 """ Locate a command script in BIN_PATH. No output if command is not found.
 """
+from __future__ import print_function
 
 
 def main(command, fullname=False):
@@ -9,7 +10,7 @@ def main(command, fullname=False):
         filename = rt.find_script_file(command)
         if not fullname:
             filename = _stash.libcore.collapseuser(filename)
-        print filename
+        print(filename)
     except Exception:
         pass
 

--- a/bin/zip.py
+++ b/bin/zip.py
@@ -1,4 +1,5 @@
 """ Package and compress (archive) files and directories """
+from __future__ import print_function
 
 import os
 import sys
@@ -20,7 +21,7 @@ def main(args):
         for path in ns.list:
             if os.path.isfile(path):
                 if ns.verbose:
-                    print path
+                    print(path)
                 arcname = os.path.relpath(path, relroot)
                 outs.write(path, arcname=arcname)
 
@@ -30,12 +31,12 @@ def main(args):
                     # add directory (needed for empty dirs)
                     outs.write(root, arcname=this_relroot)
                     if ns.verbose:
-                        print this_relroot
+                        print(this_relroot)
                     for f in files:
                         filename = os.path.join(root, f)
                         if os.path.isfile(filename):  # regular files only
                             if ns.verbose:
-                                print filename
+                                print(filename)
                             arcname = os.path.join(this_relroot, f)
                             outs.write(filename, arcname=arcname)
 

--- a/getstash.py
+++ b/getstash.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import shutil
 import sys

--- a/launch_stash.py
+++ b/launch_stash.py
@@ -3,6 +3,7 @@
 """
 Launch StaSh in a more flexible and reliable way.
 """
+from __future__ import absolute_import
 import sys
 import argparse
 
@@ -25,7 +26,7 @@ module_names = (
 if 'stash.stash' in sys.modules:
     for name in module_names:
         sys.modules.pop('stash.' + name)
-from stash import stash
+from .stash import stash
 
 ap = argparse.ArgumentParser()
 ap.add_argument('--no-cfgfile', action='store_true',

--- a/lib/git/git-branch.py
+++ b/lib/git/git-branch.py
@@ -4,15 +4,17 @@
     git branch (-m | -M) [<oldbranch>] <newbranch>
     git branch (-d | -D) [-r] <branchname>…
     git branch --edit-description [<branchname>]"""
+from __future__ import print_function
 
-import sys,os
-import dulwich
-from dulwich import porcelain
-from dulwich.walk import Walker
-from gittle import Gittle
 import argparse
+import os
+import sys
 
-from git.gitutils import _get_repo, find_revision_sha, is_ancestor, merge_base, can_ff, any_one, count_commits_between, get_remote_tracking_branch, GitError
+from six.moves import input
+
+from git.gitutils import (GitError, _get_repo, any_one,
+                          count_commits_between, find_revision_sha,
+                          get_remote_tracking_branch)
 
 
 def branch(args):
@@ -89,7 +91,7 @@ def branch(args):
         edit_branch_description(edit_description)
     elif set_upstream:
         add_tracking(set_upstream[0], *( ['origin']+set_upstream[1].split('/'))[-2:])
-        print set_upstream[0], format_tracking_branch_desc(repo,set_upstream[0])
+        print(set_upstream[0], format_tracking_branch_desc(repo,set_upstream[0]))
     elif no_track:
         if len(no_track)==1:
             remove_tracking(no_track[0])
@@ -107,7 +109,7 @@ def format_tracking_branch_desc(repo,branchname):
     except KeyError:
         return ''
 def edit_branch_description(branchname, description=None):
-    description = description or raw_input('enter description:')
+    description = description or input('enter description:')
     config = _get_repo().repo.get_config()
     if not branchname in _get_repo().branches:
         GitError('{} is not an existing branch'.format(branchname))
@@ -142,7 +144,7 @@ def delete_branch(delete_branchname,force=False,remote=None, verbose=0):
     if remote=True, then look in refs/remotes, otherwise check refs/heads
     for local, check if it has a remote tracking branch, and only allow delete if upstream has merged
     '''
-    print 'delete',delete_branchname,force,remote
+    print('delete',delete_branchname,force,remote)
     repo=_get_repo()
     if remote:
         qualified_branch=repo._format_ref_remote(delete_branchname)
@@ -164,7 +166,7 @@ def delete_branch(delete_branchname,force=False,remote=None, verbose=0):
             raise GitError('{0} is ahead of {1} by {2} commits.\nuse git branch -D\n'.format(delete_branchname,
                                     remote_tracking_branch,
                                     commits_ahead))
-    print 'removing {} (was {})\n'.format(delete_branchname,repo.refs[qualified_branch])
+    print('removing {} (was {})\n'.format(delete_branchname,repo.refs[qualified_branch]))
     del repo.repo.refs[qualified_branch]
 
     if not remote:
@@ -181,7 +183,7 @@ def move_branch(movebranch,force,verbose):
     if newbranch in repo.branches and not force:
         raise GitError('{} already exists.  use -M to force overwriting'.format(newbranch))
     if newbranch != oldbranch:
-        print 'Renaming {} ({}) to {}\n'.format(oldbranch,repo.branches[oldbranch],newbranch)
+        print('Renaming {} ({}) to {}\n'.format(oldbranch,repo.branches[oldbranch],newbranch))
         repo.add_ref(repo._format_ref_branch(newbranch),repo._format_ref_branch(oldbranch))
         del repo.repo.refs[repo._format_ref_branch(oldbranch)]
         #todo: reflog
@@ -249,17 +251,17 @@ def test():
     import os
     os.chdir('../..')
     def run(cmd):
-        print 'branch ', cmd
+        print('branch ', cmd)
         branch(cmd.split())
-        print ''
+        print('')
     #run('-d test')
     run('')
     run('-f test origin/master')
     run('')
-    print 'delete test: should delete'
+    print('delete test: should delete')
     run('-d test')
 
-    print 'set to remote'
+    print('set to remote')
     run('test origin/master')
     run('-v')
     try:
@@ -267,7 +269,7 @@ def test():
     except GitError:
         pass
     else:
-        print 'did not error!'
+        print('did not error!')
 
     run('-f test dev')
     run('-v')

--- a/lib/git/git-merge.py
+++ b/lib/git/git-merge.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 import argparse
 import os
@@ -100,28 +101,28 @@ def merge_trees(store, base, mine, theirs):
         # if mine == theirs match, use either
         elif m==t: 
             if not b.path:
-                print '  ',m.path, 'was added, but matches already'
+                print('  ',m.path, 'was added, but matches already')
             continue    #leave workng tree alone
         # if base==theirs, but not mine, already deleted (do nothing)
         elif b==t and not m.path:
-            print '   ',b.path, ' already deleted in head'
+            print('   ',b.path, ' already deleted in head')
             continue
         # if base==mine, but not theirs, delete
         elif b==m and not t.path:
-            print '  -',m.path, ' was deleted in theirs.'
+            print('  -',m.path, ' was deleted in theirs.')
             os.remove(m.path)
             removed.append(m.path)
         elif not b.path and m.path and not t.path:  #add in mine
-            print '  ',m.path ,'added in mine'
+            print('  ',m.path ,'added in mine')
             continue 
         elif not b.path and t.path and not m.path: # add theirs to mine
             # add theirs
-            print '  +',t.path, ': adding to head'
+            print('  +',t.path, ': adding to head')
             with open(t.path,'w') as f:
                 f.write(store[t.sha].data)
             added.append(t.path)
         elif not m == t: # conflict
-            print '  ?',m.path, ': merging conflicts'
+            print('  ?',m.path, ': merging conflicts')
             result=diff3.merge(store[m.sha].data.splitlines(True)
                         ,store[b.sha].data.splitlines(True) if b.sha else ['']
                         ,store[t.sha].data.splitlines(True))
@@ -160,7 +161,7 @@ def merge(args):
     --abort will remove the MERGE_HEAD and MERGE_MSG files, and will reset staging area, but wont affect files on disk.  use git reset --hard or git checkout if this is desired.
     '''
     repo=_get_repo()
-    print '_'*30
+    print('_'*30)
 
     parser=argparse.ArgumentParser(prog='merge', usage=helptext)
     parser.add_argument('commit',action='store',nargs='?', help='commit sha, local branch, or remote branch name to merge from')
@@ -169,7 +170,7 @@ def merge(args):
     result=parser.parse_args(args)
     
     if result.abort:
-        print 'attempting to undo merge.  beware, files in working tree are not touched.  \nused git reset --hard to revert particular files'
+        print('attempting to undo merge.  beware, files in working tree are not touched.  \nused git reset --hard to revert particular files')
         git_reset([])
         os.remove(os.path.join(repo.repo.controldir(),'MERGE_HEAD'))
         os.remove(os.path.join(repo.repo.controldir(),'MERGE_MSG'))
@@ -186,14 +187,14 @@ def merge(args):
     base_sha=merge_base(repo,head,merge_head)[0]  #fixme, what if multiple bases
 
     if base_sha==head:
-        print 'Fast forwarding {} to {}'.format(repo.active_branch,merge_head)
+        print('Fast forwarding {} to {}'.format(repo.active_branch,merge_head))
         repo.refs['HEAD']=merge_head
         return 
     if base_sha == merge_head:
-        print 'head is already up to date'
+        print('head is already up to date')
         return  
     
-    print 'merging <{}> into <{}>\n{} commits ahead of merge base <{}> respectively'.format(merge_head[0:7],head[0:7],count_commits_between(repo,merge_head,head),base_sha[0:7])
+    print('merging <{}> into <{}>\n{} commits ahead of merge base <{}> respectively'.format(merge_head[0:7],head[0:7],count_commits_between(repo,merge_head,head),base_sha[0:7]))
     base_tree=repo[base_sha].tree
     merge_head_tree=repo[merge_head].tree
     head_tree=repo[head].tree
@@ -207,15 +208,15 @@ def merge(args):
 
     repo.repo._put_named_file('MERGE_HEAD',merge_head)
     repo.repo._put_named_file('MERGE_MSG','Merged from {}({})'.format(merge_head, result.commit))
-    print 'Merge complete with {} conflicted files'.format(num_conflicts)
-    print '''Merged files were added to the staging area, but have not yet been comitted.   
+    print('Merge complete with {} conflicted files'.format(num_conflicts))
+    print('''Merged files were added to the staging area, but have not yet been comitted.   
     Review changes (e.g.   git diff   or   git diff>changes.txt; edit changes.txt    ), and 
     resolve any conflict markers before comitting.  
     
     Use   git add     on any files updated after resolving conflicts.  
     Run   git commit  to complete the merge process.
     
-    '''
+    ''')
 
         
 if __name__=='__main__':

--- a/lib/libcore.py
+++ b/lib/libcore.py
@@ -1,5 +1,7 @@
-import os
 import fileinput
+import os
+
+from six import text_type
 
 
 def collapseuser(path):
@@ -7,10 +9,11 @@ def collapseuser(path):
     such representation is meaningful. If path is not ~ or a
     subdirectory, the absolute path will be returned.
     """
-    path = os.path.abspath(unicode(path))
+    path = os.path.abspath(text_type(path))
     home = os.path.expanduser("~")
-    if os.path.exists(os.path.expanduser("~/Pythonista.app")):
-        althome = os.path.dirname(os.path.realpath(os.path.expanduser("~/Pythonista.app")))
+    app_dir = os.path.expanduser("~/Pythonista.app")
+    if os.path.exists(app_dir):
+        althome = os.path.dirname(os.path.realpath(app_dir))
     else:
         althome = home
 

--- a/lib/mlpatches/l2c.py
+++ b/lib/mlpatches/l2c.py
@@ -1,5 +1,6 @@
 """convert a list of args to a cmd; copied from subprocess"""
 # info: this replaces the _get_str() used previously by mlpatches
+from six import string_types
 
 
 def list2cmdline(seq):
@@ -32,7 +33,7 @@ def list2cmdline(seq):
     # http://msdn.microsoft.com/en-us/library/17w5ykft.aspx
     # or search http://msdn.microsoft.com for
     # "Parsing C++ Command-Line Arguments"
-    if isinstance(seq, (str, unicode)):
+    if isinstance(seq, string_types):
         return seq
     result = []
     needquote = False

--- a/lib/mlpatches/modules/subprocess.py
+++ b/lib/mlpatches/modules/subprocess.py
@@ -20,8 +20,11 @@
 
 import os
 import select
-import time
 import sys
+import time
+
+from six import integer_types, string_types
+
 from mlpatches import base, l2c
 
 _stash = base._stash
@@ -91,7 +94,7 @@ class Popen(object):
 		self._cwd = cwd
 		self._environ = (env if env is not None else {})
 		
-		if isinstance(args, (str, unicode)):
+		if isinstance(args, string_types):
 			self.cmd = args
 		else:
 			if args[0] == sys.executable:
@@ -112,7 +115,7 @@ class Popen(object):
 			self._fds += [rfd, wfd]
 			self.stdout = os.fdopen(rfd, rfm, bufsize)
 			self._sp_stdout = os.fdopen(wfd, "wb")
-		elif isinstance(stdout, (int, long)):
+		elif isinstance(stdout, integer_types):
 			# use fd
 			self.stdout = None
 			self._fds.append(stdout)
@@ -135,7 +138,7 @@ class Popen(object):
 		elif stderr == STDOUT:
 			self.stderr = self.stdout
 			self._sp_stderr = self._sp_stdout
-		elif isinstance(stderr, (int, long)):
+		elif isinstance(stderr, integer_types):
 			# use fd
 			self.stderr = None
 			self._fds.append(stderr)
@@ -155,7 +158,7 @@ class Popen(object):
 			self._fds += [rfd, wfd]
 			self.stdin = os.fdopen(wfd, "wb")
 			self._sp_stdin = os.fdopen(rfd, "rb")
-		elif isinstance(stdin, (int, long)):
+		elif isinstance(stdin, integer_types):
 			# use fd
 			self.stdin = None
 			self._fds.append(stdin)

--- a/lib/mlpatches/mount_base.py
+++ b/lib/mlpatches/mount_base.py
@@ -1,18 +1,18 @@
 """base patches for mount."""
 import os
 import stat as _stat
-import __builtin__
+
+from six import text_type
+from six.moves import builtins
 
 from mlpatches import base
-
-from stashutils.mount_ctrl import get_manager
 from stashutils.fsi.errors import IsFile, OperationFailure
-
+from stashutils.mount_ctrl import get_manager
 
 # store default functions
 
 _org_listdir = os.listdir
-_org_open = __builtin__.open
+_org_open = builtins.open
 _org_chdir = os.chdir
 _org_getcwd = os.getcwd
 _org_ismount = os.path.ismount
@@ -88,7 +88,7 @@ def getcwd(patch):
 
 def getcwdu(patch):
 	"""Return a Unicode object representing the current working directory."""
-	return unicode(CWD)
+	return text_type(CWD)
 
 
 def chdir(patch, path):
@@ -199,10 +199,10 @@ def lstat(patch, path):
 				)
 
 
-def mkdir(patch, path, mode=0777):
+def mkdir(patch, path, mode=0o777):
 	"""
 	Create a directory named path with numeric mode mode.
-	The default mode is 0777 (octal). On some systems, mode is ignored.
+	The default mode is 0o777 (octal). On some systems, mode is ignored.
 	Where it is used, the current umask value is first masked out.
 	If the directory already exists, OSError is raised.
 	"""
@@ -312,7 +312,7 @@ def access(patch, path, mode):
 			return False
 		if mode == os.F_OK:
 			return True
-		fa_mode = s.st_mode #  & 0777
+		fa_mode = s.st_mode  #  & 0o777
 		should_read = mode & os.R_OK
 		should_write = mode & os.W_OK
 		should_exec = mode & os.X_OK
@@ -367,8 +367,8 @@ class ListdirPatch(base.FunctionPatch):
 
 
 class OpenPatch(base.FunctionPatch):
-	"""patch for __builtin__.open()"""
-	module = "__builtin__"
+	"""patch for builtins.open()"""
+	module = "builtins"
 	function = "open"
 	replacement = open
 

--- a/lib/mlpatches/tests/sp_test.py
+++ b/lib/mlpatches/tests/sp_test.py
@@ -1,42 +1,43 @@
 """subprocess tests."""
+from __future__ import print_function
 import subprocess
 
 _stash = globals()["_stash"]
 text = _stash.text_color
 
 # exit test
-print text("starting exit test...", "yellow")
+print(text("starting exit test...", "yellow"))
 try:
 	subprocess.check_call("exit 0")
-	print text("	0 OK", "green")
+	print(text("	0 OK", "green"))
 except subprocess.CalledProcessError:
-	print text("	0 ERROR", "red")
+	print(text("	0 ERROR", "red"))
 try:
 	subprocess.check_call("exit 1")
-	print text("	1 ERROR", "red")
+	print(text("	1 ERROR", "red"))
 except subprocess.CalledProcessError:
-	print text("	1 OK", "green")
+	print(text("	1 OK", "green"))
 
 # parent I/O
-print text("\nstarting parent I/O test...", "yellow")
-print "		please check for I/O"
+print(text("\nstarting parent I/O test...", "yellow"))
+print("		please check for I/O")
 subprocess.call("man readme")
 
 # output test
-print text("\nstarting check_output test...", "yellow")
+print(text("\nstarting check_output test...", "yellow"))
 string = "Test"
 try:
 	output = subprocess.check_output("echo "+string)
 	if output.endswith("\n") and (not string.endswith("\n")):
 		output = output[:-1]
 	if output != string:
-		print text("	0 ERROR output does not match!\n	"+output, "red")
+		print(text("	0 ERROR output does not match!\n	"+output, "red"))
 	else:
-		print text("	0 OK", "green")
+		print(text("	0 OK", "green"))
 except subprocess.CalledProcessError:
-	print text("	0 ERROR", "red")
+	print(text("	0 ERROR", "red"))
 try:
 	output = subprocess.check_output("gci wasd")
-	print text("	1 ERROR", "red")
+	print(text("	1 ERROR", "red"))
 except subprocess.CalledProcessError:
-	print text("	1 OK", "green")
+	print(text("	1 OK", "green"))

--- a/lib/stashutils/extensions.py
+++ b/lib/stashutils/extensions.py
@@ -2,13 +2,13 @@
 import os
 import shutil
 
+from six import string_types
+
 from stash.system.shcommon import _STASH_EXTENSION_BIN_PATH as EBP
-from stash.system.shcommon import _STASH_EXTENSION_MAN_PATH as EMP
 from stash.system.shcommon import _STASH_EXTENSION_FSI_PATH as EFP
+from stash.system.shcommon import _STASH_EXTENSION_MAN_PATH as EMP
 from stash.system.shcommon import _STASH_EXTENSION_PATCH_PATH as EPP
-
 from stashutils.core import load_from_dir
-
 
 # alias load_from_dir (so you can access it trough this namespace)
 load_from_dir = load_from_dir
@@ -20,7 +20,7 @@ def create_file(dest, content):
 	If content is a string or unicode, use it as the content.
 	Otherwise, use content.read() as the content.
 	"""
-	if not isinstance(content, (str, unicode)):
+	if not isinstance(content, string_types):
 		content = content.read()
 	with open(dest, "wb") as f:
 		f.write(content)

--- a/lib/stashutils/fsi/DropBox.py
+++ b/lib/stashutils/fsi/DropBox.py
@@ -1,4 +1,5 @@
 """The FSI for dropbox."""
+from __future__ import absolute_import
 # this module is named 'DropBox' instead of 'dropbox' to avoid a
 # naming conflict.
 import os
@@ -6,7 +7,7 @@ import logging
 import stat
 import tempfile
 
-import dropbox
+from . import dropbox
 
 from stashutils.fsi.errors import OperationFailure, IsDir, IsFile
 from stashutils.fsi.errors import AlreadyExists
@@ -178,7 +179,7 @@ class DropboxFSI(BaseFSI):
 				raise OperationFailure(e.message)
 			if isinstance(meta, (
 				dropbox.files.FolderMetadata,
-				dropbox.sharing.SharedFolderMetadata,
+				dropbox.sharing.SharedFolderMetadata
 				)):
 				bytes = 0
 				isdir = True

--- a/lib/stashutils/fsi/zip.py
+++ b/lib/stashutils/fsi/zip.py
@@ -6,7 +6,7 @@ import time
 import shutil
 import datetime
 import stat
-import StringIO
+from six import StringIO
 
 from stashutils.fsi import base
 from stashutils.fsi import errors
@@ -197,7 +197,7 @@ class ZipWriter(object):
 		self.name = fp
 		self.buffering = buffering
 		self.mode = mode
-		self.sio = StringIO.StringIO()
+		self.sio = StringIO()
 		self.closed = False
 	
 	def close(self):
@@ -230,7 +230,7 @@ class ZipReader(ZipWriter):
 		self.name = fp
 		self.buffering = buffering
 		self.mode = mode
-		self.sio = StringIO.StringIO(self.root.zf.read(fp))
+		self.sio = StringIO(self.root.zf.read(fp))
 		self.closed = False
 	
 	def close(self):

--- a/lib/stashutils/mount_manager.py
+++ b/lib/stashutils/mount_manager.py
@@ -1,13 +1,13 @@
 """This module coordinates the mount-system."""
 import os
 
+from six import string_types
+
+from mlpatches.mount_patches import MOUNT_PATCHES
 from stashutils.core import get_stash
 from stashutils.fsi.base import BaseFSI
 from stashutils.fsi.errors import OperationFailure
-from stashutils.mount_ctrl import set_manager, get_manager
-
-from mlpatches.mount_patches import MOUNT_PATCHES
-
+from stashutils.mount_ctrl import get_manager, set_manager
 
 _stash = get_stash()
 
@@ -15,8 +15,8 @@ _stash = get_stash()
 # Exceptions
 
 class MountError(Exception):
-	"""raised when a mount failed."""
-	pass
+    """raised when a mount failed."""
+    pass
 
 
 # the manager
@@ -64,7 +64,7 @@ class MountManager(object):
 		"""mounts a fsi to a path."""
 		if not isinstance(fsi, BaseFSI):
 			raise ValueError("Expected a FSI!")
-		if not isinstance(path, (str, unicode)):
+		if not isinstance(path, string_types):
 			raise ValueError("Expected a string or unicode!")
 		path = os.path.abspath(path)
 		if path in self.path2fs:

--- a/stash.py
+++ b/stash.py
@@ -7,29 +7,33 @@ https://github.com/ywangd/stash
 
 __version__ = '0.6.20'
 
-import os
-import sys
-from ConfigParser import ConfigParser
-from StringIO import StringIO
 import imp as pyimp  # rename to avoid name conflict with objc_util
 import logging
 import logging.handlers
+import os
+import sys
 
+from six import StringIO
+from six.moves.configparser import ConfigParser
 
 # noinspection PyPep8Naming
-from .system.shcommon import IN_PYTHONISTA, ON_IPAD
-from .system.shcommon import _STASH_ROOT, _STASH_CONFIG_FILES, _SYS_STDOUT
-from .system.shcommon import Graphics as graphics, Control as ctrl, Escape as esc
-from .system.shcommon import _EXTERNAL_DIRS
-from .system.shuseractionproxy import ShUserActionProxy
-from .system.shiowrapper import enable as enable_io_wrapper, disable as disable_io_wrapper
-from .system.shparsers import ShParser, ShExpander, ShCompleter
-from .system.shruntime import ShRuntime
-from .system.shstreams import ShMiniBuffer, ShStream
-from .system.shscreens import ShSequentialScreen, ShSequentialRenderer
-from .system.shui import ShUI
+from .system.shcommon import (_EXTERNAL_DIRS, _STASH_CONFIG_FILES, _STASH_ROOT,
+                              _SYS_STDOUT, IN_PYTHONISTA, ON_IPAD)
+from .system.shcommon import Control as ctrl, Escape as esc, Graphics as graphics
 from .system.shio import ShIO
+from .system.shiowrapper import disable as disable_io_wrapper
+from .system.shiowrapper import enable as enable_io_wrapper
+from .system.shparsers import ShCompleter, ShExpander, ShParser
+from .system.shruntime import ShRuntime
+from .system.shscreens import ShSequentialRenderer, ShSequentialScreen
+from .system.shstreams import ShMiniBuffer, ShStream
+from .system.shui import ShUI
+from .system.shuseractionproxy import ShUserActionProxy
 
+try:
+    file           # Python 2
+except NameError:  # Python 3
+    from io import IOBase as file
 
 # Setup logging
 LOGGER = logging.getLogger('StaSh')
@@ -249,9 +253,8 @@ class StaSh(object):
         :return:
         """
         # No color for pipes, files and Pythonista console
-        if not always and (isinstance(sys.stdout, StringIO)
-                           or isinstance(sys.stdout, file)
-                           or sys.stdout.write.im_self is _SYS_STDOUT):
+        if not always and (isinstance(sys.stdout, (file, StringIO)) or
+                           sys.stdout.write.__self__ is _SYS_STDOUT):
             return s
 
         fmt_string = u'%s%%d%s%%s%s%%d%s' % (ctrl.CSI, esc.SGR, ctrl.CSI, esc.SGR)

--- a/system/shcommon.py
+++ b/system/shcommon.py
@@ -2,13 +2,15 @@
 """
 The Control, Escape and Graphics are taken from pyte (https://github.com/selectel/pyte)
 """
-import os
-import sys
-import platform
-import functools
-import threading
 import ctypes
+import functools
+import os
+import platform
+import sys
+import threading
 from itertools import chain
+
+from six import text_type
 
 IN_PYTHONISTA = sys.executable.find('Pythonista') >= 0
 
@@ -119,7 +121,7 @@ if IN_PYTHONISTA:
             def write(self, s):
                 if isinstance(s, str):
                     _outputcapture.CaptureStdout(s)
-                elif isinstance(s, unicode):
+                elif isinstance(s, text_type):
                     _outputcapture.CaptureStdout(s.encode('utf8'))
 
             def writelines(self, lines):
@@ -143,7 +145,7 @@ if IN_PYTHONISTA:
             def write(self, s):
                 if isinstance(s, str):
                     _outputcapture.CaptureStderr(s)
-                elif isinstance(s, unicode):
+                elif isinstance(s, text_type):
                     _outputcapture.CaptureStderr(s.encode('utf8'))
 
             def writelines(self, lines):

--- a/system/shparsers.py
+++ b/system/shparsers.py
@@ -1,16 +1,16 @@
 # coding: utf-8
 
-import os
-import string
 import glob
 import logging
+import os
+import string
 import threading
-from StringIO import StringIO
 
 import pyparsing as pp
+from six import StringIO
 
-from .shcommon import ShSingleExpansionRequired, ShBadSubstitution, ShInternalError
-
+from .shcommon import (ShBadSubstitution, ShInternalError,
+                       ShSingleExpansionRequired)
 
 _GRAMMAR = r"""
 -----------------------------------------------------------------------------

--- a/system/shscreens.py
+++ b/system/shscreens.py
@@ -2,22 +2,27 @@
 """
 In-memory screen related code.
 """
-import logging
-from time import time
+from __future__ import absolute_import
 
-import threading
 import itertools
+import logging
+import threading
 from collections import deque, namedtuple
 from contextlib import contextmanager
+from time import time
 
+from six.moves import xrange
+
+from .shcommon import IN_PYTHONISTA, ON_IOS_8
+from .shcommon import Graphics as graphics
+from .shcommon import sh_delay
+
+# noinspection PyPep8Naming
 try:
     from objc_util import *
 except ImportError:
-    from dummyobjc_util import *
+    from .dummyobjc_util import *
 
-from .shcommon import IN_PYTHONISTA, ON_IOS_8
-# noinspection PyPep8Naming
-from .shcommon import sh_delay, Graphics as graphics
 
 NSMutableAttributedString = ObjCClass('NSMutableAttributedString')
 UIFont = ObjCClass('UIFont')

--- a/system/shstreams.py
+++ b/system/shstreams.py
@@ -8,7 +8,8 @@ for accepting outputs from running scripts.
 import logging
 import re
 
-# noinspection PyPep8Naming
+from six import text_type
+
 from .shcommon import Control as ctrl, Escape as esc
 
 
@@ -364,7 +365,7 @@ class ShStream(object):
         :param str chars: a string to feed from.
         """
         # To avoid the \xc2 deadlock from bytes string
-        if not isinstance(chars, unicode):
+        if not isinstance(chars, text_type):
             chars = chars.decode('utf-8', errors='ignore')
 
         with self.main_screen.acquire_lock():

--- a/system/shterminal.py
+++ b/system/shterminal.py
@@ -2,6 +2,7 @@
 """
 Physical terminal is what an user sees.
 """
+from __future__ import absolute_import
 import ast
 import logging
 
@@ -9,7 +10,7 @@ try:
     import ui
     from objc_util import *
 except ImportError:
-    import dummyui as ui
+    from . import dummyui as ui
     from .dummyobjc_util import *
 
 from .shcommon import CTRL_KEY_FLAG

--- a/system/shui.py
+++ b/system/shui.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from __future__ import absolute_import
 import time
 import logging
 
@@ -6,7 +7,7 @@ import logging
 try:
     import ui
 except ImportError:
-    import dummyui as ui
+    from . import dummyui as ui
 
 from .shcommon import IN_PYTHONISTA, ON_IPAD, PYTHONISTA_VERSION_LONG
 from .shterminal import ShTerminal, StubTerminal

--- a/system/tests/data/test05.py
+++ b/system/tests/data/test05.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 s = globals()['_stash']
 
 # following statements should be correlated
@@ -11,7 +12,7 @@ s('cd bin')
 s('pwd -b')
 s('cd ..')
 
-print
+print()
 # following two scripts should not interfere each other
 s('test05_1.sh')
 

--- a/system/tests/data/test_101_1.py
+++ b/system/tests/data/test_101_1.py
@@ -1,6 +1,7 @@
 # coding=utf-8
+from __future__ import print_function
 import time
 
 for i in range(2):
-    print 'sleeping ... {}'.format(i)
+    print('sleeping ... {}'.format(i))
     time.sleep(1)

--- a/system/tests/data/test_102_1.py
+++ b/system/tests/data/test_102_1.py
@@ -1,8 +1,9 @@
 # coding=utf-8
+from __future__ import print_function
 import os
 import time
 
 
 for i in range(5):
-    print '{}'.format(os.path.basename(__file__))
+    print('{}'.format(os.path.basename(__file__)))
     time.sleep(.5)

--- a/system/tests/data/test_102_2.py
+++ b/system/tests/data/test_102_2.py
@@ -1,7 +1,8 @@
 # coding=utf-8
+from __future__ import print_function
 import os
 import time
 
 for i in range(5):
-    print '{}'.format(os.path.basename(__file__))
+    print('{}'.format(os.path.basename(__file__)))
     time.sleep(.5)

--- a/system/tests/data/test_12.py
+++ b/system/tests/data/test_12.py
@@ -1,13 +1,14 @@
+from __future__ import print_function
 import os
 
 _stash = globals()['_stash']
 
-print 'parent script {}'.format(os.path.basename(os.getcwd()))
+print('parent script {}'.format(os.path.basename(os.getcwd())))
 # Change directory in sub-shell
 _stash('test_12_1.py')
 # Directory in parent shell is not changed
-print 'parent script {}'.format(os.path.basename(os.getcwd()))
+print('parent script {}'.format(os.path.basename(os.getcwd())))
 # Following calls to sub-shell remembers the directory change in last call
 _stash('test_12_2.py')
 # Directory in parent shell is still the same
-print 'parent script {}'.format(os.path.basename(os.getcwd()))
+print('parent script {}'.format(os.path.basename(os.getcwd())))

--- a/system/tests/data/test_12_2.py
+++ b/system/tests/data/test_12_2.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 
-print 'from child script 2 {}'.format(os.path.basename(os.getcwd()))
+print('from child script 2 {}'.format(os.path.basename(os.getcwd())))

--- a/system/tests/data/test_201.py
+++ b/system/tests/data/test_201.py
@@ -1,1 +1,2 @@
-print 'The first line\nA quick brown fox jumps over the lazy dog\r',
+from __future__ import print_function
+print('The first line\nA quick brown fox jumps over the lazy dog\r', end=' ')

--- a/system/tests/data/test_202.py
+++ b/system/tests/data/test_202.py
@@ -1,1 +1,2 @@
-print 'The first line\nA quick brown fox jumps over the lazy dog\r\033[0P',
+from __future__ import print_function
+print('The first line\nA quick brown fox jumps over the lazy dog\r\033[0P', end=' ')

--- a/system/tests/data/test_203.py
+++ b/system/tests/data/test_203.py
@@ -1,1 +1,2 @@
-print 'The first line\nA quick brown fox jumps over the lazy dog\r\033[2K',
+from __future__ import print_function
+print('The first line\nA quick brown fox jumps over the lazy dog\r\033[2K', end=' ')

--- a/system/tests/data/test_204.py
+++ b/system/tests/data/test_204.py
@@ -1,1 +1,2 @@
-print 'The first line\nA quick brown fox jumps over the lazy dog\b',
+from __future__ import print_function
+print('The first line\nA quick brown fox jumps over the lazy dog\b', end=' ')

--- a/system/tests/test_completer.py
+++ b/system/tests/test_completer.py
@@ -53,7 +53,7 @@ class CompleterTests(unittest.TestCase):
         assert newline == 'git branch '
 
     def test_completion_09(self):
-        newline, possibilities = self.complete('$STASH_')
+        newline, possibilities = self.complete('$STASH')
         assert newline == '$STASH_ROOT '
 
     def test_completion_10(self):

--- a/system/tests/test_expander.py
+++ b/system/tests/test_expander.py
@@ -16,8 +16,8 @@ class ExpanderTests(unittest.TestCase):
 
     def _get_pipe_sequence(self, line):
         expanded = self.expand(line)
-        expanded.next()
-        return expanded.next()
+        next(expanded)
+        return next(expanded)
 
     def test_envars(self):
         pipe_sequence = self._get_pipe_sequence(r'ls $SELFUPDATE_BRANCH')

--- a/system/tests/test_threads.py
+++ b/system/tests/test_threads.py
@@ -1,10 +1,10 @@
 # coding=utf-8
-import os
 import time
 import unittest
-from StringIO import StringIO
 
+from six import StringIO
 from stash import stash
+
 
 class ThreadsTests(unittest.TestCase):
 


### PR DESCRIPTION
Some minimal, "safe" changes to make the code syntax compatible with both Python 2 and Python 3.
* Run [__futurize --stage1 -w__](http://python-future.org/futurize_cheatsheet.html)
* Use the [__six__ module](http://six.readthedocs.io) to support both Python 2 and Python 3.

Python 3 syntax compatibility does not mean that the port is complete.