### PR TITLE
add py3 warning on startup; version bump; minor bugfixes and improvements

### DIFF
--- a/bin/easy_config.py
+++ b/bin/easy_config.py
@@ -261,7 +261,7 @@ class ColorPicker(object):
 	@property
 	def hexcode(self):
 		"""returns the selected color as a html-like hexcode"""
-		hexc = "#%.02X%.02X%.02X" % self.rgb_255
+		hexc = "#%.02X%.02X%.02X" % (int(self.rgb_255[0]), int(self.rgb_255[1]), int(self.rgb_255[2]))
 		return hexc
 	
 	@property
@@ -401,7 +401,7 @@ class ConfigView(ui.View):
 			b = ui.Button()
 			rawcolor = _stash.config.get(sn, info["option_name"])
 			color = ast.literal_eval(rawcolor)
-			rgb255color = color[0] * 255, color[1] * 255, color[2] * 255
+			rgb255color = int(color[0] * 255), int(color[1] * 255), int(color[2] * 255)
 			b.background_color = color
 			b.title = "#%.02X%.02X%.02X" % rgb255color
 			b.tint_color = ((0, 0, 0) if color[0] >= 0.5 else (1, 1, 1))

--- a/bin/monkeylord.py
+++ b/bin/monkeylord.py
@@ -10,6 +10,14 @@ _stash = globals()["_stash"]
 from mlpatches import patches
 
 
+def patch_is_compatible(patch):
+	"""Return True if the patch is compatible."""
+	if _stash.PY3:
+		return patch.PY3
+	else:
+		return patch.PY2
+
+
 def save_config(path):
 	"""save the current config to path."""
 	ts = {}
@@ -62,6 +70,14 @@ def main(ns):
 				)
 			sys.exit(1)
 		patch = patches.PATCHES[name]
+		if not patch_is_compatible(patch):
+			print(
+				_stash.text_color(
+					"Error: Patch '{n}' not compatible with this python version!".format(n=name),
+					"red"
+					)
+				)
+			sys.exit(1)
 		patch.enable()
 	elif ns.action == "disable":
 		# disable a patch
@@ -74,6 +90,14 @@ def main(ns):
 				)
 			sys.exit(1)
 		patch = patches.PATCHES[name]
+		if not patch_is_compatible(patch):
+			print(
+				_stash.text_color(
+					"Error: Patch '{n}' not compatible with this python version!".format(n=name),
+					"red"
+					)
+				)
+			sys.exit(1)
 		patch.disable()
 	elif ns.action == "list":
 		# show monkeypatches and their state
@@ -81,6 +105,8 @@ def main(ns):
 		mlength = max([len(e) for e in patches.PATCHES.keys()]) + 2
 		for pn in sorted(patches.PATCHES.keys()):
 			patch = patches.PATCHES[pn]
+			if not patch_is_compatible(patch):
+				continue
 			if patch.enabled:
 				t = "[enabled]"
 				c = "green"
@@ -98,6 +124,7 @@ def main(ns):
 		save_config(name)
 	elif ns.action == "loadconf":
 		load_config(name)
+
 
 if __name__ == "__main__":
 	# main code

--- a/core.py
+++ b/core.py
@@ -153,6 +153,22 @@ class StaSh(object):
         		always=True,
         		),
         	)
+        # warn on py3
+        if self.PY3:
+            self.io.write(
+                self.text_style(
+                    'Warning: you are running StaSh in python3. Some commands may not work correctly in python3.\n',
+                    {'color': 'red'},
+                    always=True,
+                    ),
+                )
+            self.io.write(
+                self.text_style(
+                    'Please help us improving StaSh by reporting bugs on github.\n',
+                    {'color': 'yellow', 'traits': ['italic']},
+                    always=True,
+                    ),
+                )
         # Load shared libraries
         self._load_lib()
 
@@ -163,7 +179,6 @@ class StaSh(object):
         if command:
         	# do not run command if command is False (but not None)
             self(command, add_to_history=False, persistent_level=0)
-
     def __call__(self, input_, persistent_level=2, *args, **kwargs):
         """ This function is to be called by external script for
          executing shell commands """

--- a/core.py
+++ b/core.py
@@ -5,7 +5,7 @@ StaSh - Pythonista Shell
 https://github.com/ywangd/stash
 """
 
-__version__ = '0.6.20'
+__version__ = '0.7.0'
 
 import imp as pyimp  # rename to avoid name conflict with objc_util
 import logging

--- a/lib/mlpatches/mount_base.py
+++ b/lib/mlpatches/mount_base.py
@@ -368,25 +368,59 @@ class ListdirPatch(base.FunctionPatch):
 	replacement = listdir
 
 
-class OpenPatch(base.FunctionPatch):
+class Py2OpenPatch(base.FunctionPatch):
+	"""patch for builtins.open()"""
+	PY3 = base.SKIP
+	module = "__builtin__"
+	function = "open"
+	replacement = open
+
+
+class Py3OpenPatch(base.FunctionPatch):
+	"""patch for builtins.open()"""
+	PY2 = base.SKIP
+	module = "builtins"
+	function = "open"
+	replacement = open
+
+
+class SixOpenPatch(base.FunctionPatch):
 	"""patch for builtins.open()"""
 	module = "six.moves.builtins"
 	function = "open"
 	replacement = open
 
 
-class GetcwdPatch(base.FunctionPatch):
+class Py2GetcwdPatch(base.FunctionPatch):
 	"""patch for os.getcwd()"""
+	PY3 = base.SKIP
 	module = "os"
 	function = "getcwd"
 	replacement = getcwd
 
 
-class GetcwduPatch(base.FunctionPatch):
+class Py3GetcwdPatch(base.FunctionPatch):
+	"""patch for os.getcwd()"""
+	PY2 = base.SKIP
+	module = "os"
+	function = "getcwd"
+	replacement = getcwdu
+
+
+class Py2GetcwduPatch(base.FunctionPatch):
 	"""patch for os.getcwdu()"""
+	PY3 = base.SKIP
 	module = "os"
 	function = "getcwdu"
 	replacement = getcwdu
+
+
+class Py3GetcwdbPatch(base.FunctionPatch):
+	"""patch for os.getcwd()"""
+	PY2 = base.SKIP
+	module = "os"
+	function = "getcwdb"
+	replacement = getcwd
 
 
 class ChdirPatch(base.FunctionPatch):
@@ -455,9 +489,16 @@ class ChmodPatch(base.FunctionPatch):
 # create patch instances
 
 LISTDIR_PATCH = ListdirPatch()
-OPEN_PATCH = OpenPatch()
-GETCWD_PATCH = GetcwdPatch()
-GETCWDU_PATCH = GetcwduPatch()
+
+PY2_OPEN_PATCH = Py2OpenPatch()
+PY3_OPEN_PATCH = Py3OpenPatch()
+SIX_OPEN_PATCH = SixOpenPatch()
+
+PY2_GETCWD_PATCH = Py2GetcwdPatch()
+PY3_GETCWD_PATCH = Py3GetcwdPatch()
+PY2_GETCWDU_PATCH = Py2GetcwduPatch()
+PY3_GETCWDB_PATCH = Py3GetcwdbPatch()
+
 CHDIR_PATCH = ChdirPatch()
 ISMOUNT_PATCH = IsmountPatch()
 STAT_PATCH = StatPatch()

--- a/lib/mlpatches/mount_patches.py
+++ b/lib/mlpatches/mount_patches.py
@@ -3,12 +3,12 @@ from mlpatches.base import PatchGroup
 from mlpatches import mount_base
 from stashutils import mount_ctrl
 
-_BASE_PATCHES = filter(
+_BASE_PATCHES = list(filter(
 	None,
 	[
 		getattr(mount_base, p) if p.endswith("PATCH") else None for p in dir(mount_base)
 		]
-	)
+	))
 
 
 class MountPatches(PatchGroup):

--- a/lib/mlpatches/patches.py
+++ b/lib/mlpatches/patches.py
@@ -54,10 +54,9 @@ PATCHES.update(STABLE_PATCHES)  # update with STABLE patches (overwriting INSTAB
 
 
 # define a PatchGroup with all patches
-
-STABLE_GROUP = base.VariablePatchGroup(STABLE_PATCHES.values())
-INSTABLE_GROUP = base.VariablePatchGroup(INSTABLE_PATCHES.values())
-ALL_GROUP = base.VariablePatchGroup(PATCHES.values())
+STABLE_GROUP = base.VariablePatchGroup(list(STABLE_PATCHES.values()))
+INSTABLE_GROUP = base.VariablePatchGroup(list(INSTABLE_PATCHES.values()))
+ALL_GROUP = base.VariablePatchGroup(list(PATCHES.values()))
 
 
 PATCHES["ALL"] = ALL_GROUP


### PR DESCRIPTION
Hi,
this PR adds a warning which will be shown if StaSh is started with python3.
It also contains the version bump to `0.7.0` (As discussed in #311 ).
Other than that, there are also some minor improvements and bugfixes regarding py3 compatibility.
Since the version detection of stash changed in a backwards incompatible way, a forceupdate (`selfupdate -f`) is required to update from  `0.6.20` or older to `0.7.0`)

Also, there seem to be a lot of issues which could be closed. Should i compile a list of all issues which can be closed?