### PR TITLE
Fix error occurred when try to use `selfupdate` in older version of StaSh.

### DIFF
--- a/bin/selfupdate.py
+++ b/bin/selfupdate.py
@@ -33,7 +33,7 @@ def get_remote_version(owner, branch):
     """
     import ast
 
-    url = '%s/%s/core.py?q=%s' % (URL_BASE.format(owner=owner), branch, randint(1, 999999))
+    url = '%s/%s/stash.py?q=%s' % (URL_BASE.format(owner=owner), branch, randint(1, 999999))
 
     try:
         req = requests.get(url)

--- a/stash.py
+++ b/stash.py
@@ -1,0 +1,13 @@
+# coding: utf-8
+"""
+StaSh - Pythonista Shell
+
+https://github.com/ywangd/stash
+"""
+
+"""
+HeadsUP: This file is ONLY for old clients to do `selfupdate`.
+The new main core file is at `core.py`.
+"""
+
+__version__ = '0.7.0'


### PR DESCRIPTION
Fix #318 
Changing:
**\+**  /stash.py - Where old version of StaSh was using to get the latest version of StaSh.
**~**  /bin/selfupdate.py - Renamed to the latest core version of StaSh. 