### PR TITLE
wheel support for pip

### DIFF
--- a/bin/pip.py
+++ b/bin/pip.py
@@ -94,6 +94,11 @@ class PipError(Exception):
     pass
 
 
+class PackageAlreadyInstalled(PipError):
+	"""Error raised when a package is already installed."""
+	pass
+	
+
 class OmniClass(object):
     def __init__(self, *args, **kwargs):
         pass
@@ -865,7 +870,12 @@ class PackageRepository(object):
 
             print('Installing dependency: {}'.format('{}{}'.format(pkg_name, ver_spec if ver_spec else '')))
             repository = get_repository(pkg_name)
-            repository.install(pkg_name, ver_spec)
+            try:
+                repository.install(pkg_name, ver_spec)
+            except PackageAlreadyInstalled:
+                # well, it is already installed...
+                # TODO: maybe update package if required?
+                pass
 
     def search(self, name_fragment):
         raise PipError('search only available for PyPI packages')
@@ -1040,7 +1050,8 @@ class PyPIRepository(PackageRepository):
             archive_filename, pkg_info = self.download(pkg_name, ver_spec, wheel_priority=True)
             self._install(pkg_name, pkg_info, archive_filename)
         else:
-            raise PipError('Package already installed')
+        	# todo: maybe update package?
+            raise PackageAlreadyInstalled('Package already installed')
 
     def update(self, pkg_name):
         pkg_name = self.get_standard_package_name(pkg_name)

--- a/bin/pip.py
+++ b/bin/pip.py
@@ -28,6 +28,7 @@ import requests
 import re
 import operator
 import traceback
+import codecs
 
 import six
 from distutils.util import convert_path
@@ -759,7 +760,7 @@ if __name__ == "__main__":
         Get AST of the setup file and also transform it for fake setuptools
         and stub setup calls.
         """
-        with open(filename) as ins:
+        with codecs.open(filename, mode="r", encoding="UTF-8") as ins:
             s = ins.read()
         tree = ast.parse(s, filename=filename, mode='exec')
         ArchiveFileInstaller.SetupTransformer().visit(tree)
@@ -1230,7 +1231,9 @@ class VersionSpecifier(object):
                 requirement = requirement[0]
             else:
                 raise PipError("Unknown requirement format: " + repr(requirement))
-        requirement = requirement.replace(' ', '')  # remove all whitespaces
+        # remove all whitespaces and '()'
+        requirement = requirement.replace(' ', '')
+        requirement = requirement.replace("(", "").replace(")", "")
         if requirement.startswith("#"):
             # ignore
             return None, None

--- a/lib/stashutils/wheels.py
+++ b/lib/stashutils/wheels.py
@@ -255,6 +255,10 @@ class DependencyHandler(BaseHandler):
 	
 	def handle_install(self, src, dest):
 		metap = os.path.join(src, self.distinfo_name, "metadata.json")
+		if not os.path.exists(metap):
+			if self.verbose:
+				print("Warning: could not find 'metadata.json', can not detect dependencies!")
+			return
 		with open(metap, "r") as fin:
 			content = json.load(fin)
 		dependencies = content.get("run_requires", [{"requires": []}])[0]["requires"]

--- a/lib/stashutils/wheels.py
+++ b/lib/stashutils/wheels.py
@@ -189,12 +189,12 @@ class ConsoleScriptsHandler(BaseHandler):
 			desc = json.load(fin).get("summary", "???")
 		
 		for command, definition in parser.items(section="console_scripts"):
-			name, loc = definition.replace(" ", "").split("=")
-			modname, funcname = loc.split(":")
-			if not name.endswith(".py"):
-				name += ".py"
+			# name, loc = definition.replace(" ", "").split("=")
+			modname, funcname = definition.split(":")
+			if not command.endswith(".py"):
+				command += ".py"
 			path = create_command(
-				name,
+				command,
 				(u"""'''%s'''
 from %s import %s
 

--- a/lib/stashutils/wheels.py
+++ b/lib/stashutils/wheels.py
@@ -1,0 +1,309 @@
+"""functions and classes related to wheels."""
+import os
+import shutil
+import tempfile
+import json
+import re
+import zipfile
+
+import six
+from six.moves import configparser
+
+from stashutils.extensions import create_command
+
+
+class WheelError(Exception):
+	"""Error related to a wheel."""
+	pass
+
+
+def parse_wheel_name(filename):
+	"""
+	Parse the filename of a wheel and return the information as dict.
+	"""
+	if not filename.endswith(".whl"):
+		raise WheelError("PEP427 violation: wheels need to end with '.whl'")
+	else:
+		filename = filename[:-4]
+	splitted = filename.split("-")
+	distribution = splitted[0]
+	version = splitted[1]
+	if len(splitted) == 6:
+		build_tag = splitted[2]
+		python_tag = splitted[3]
+		abi_tag = splitted[4]
+		platform_tag = splitted[5]
+	elif len(splitted) == 5:
+		build_tag = None
+		python_tag = splitted[2]
+		abi_tag = splitted[3]
+		platform_tag = splitted[4]
+	else:
+		raise WheelError("PEP427 violation: invalid naming schema")
+	return {
+		"distribution": distribution,
+		"version": version,
+		"build_tag": build_tag,
+		"python_tag": python_tag,
+		"abi_tag": abi_tag,
+		"platform_tag": platform_tag,
+	}
+
+
+def escape_filename_component(fragment):
+	"""
+	Escape a component of the filename as specified in PEP 427.
+	"""
+	return re.sub("[^\w\d.]+", "_", fragment, re.UNICODE)
+
+
+def generate_filename(
+	distribution,
+	version,
+	build_tag=None,
+	python_tag=None,
+	abi_tag=None,
+	platform_tag=None,
+	):
+	"""
+	Generate a filename for the wheel and return it.
+	"""
+	if python_tag is None:
+		if six.PY3:
+			python_tag = "py3"
+		else:
+			python_tag = "py2"
+	if abi_tag is None:
+		abi_tag = "none"
+	if platform_tag is None:
+		platform_tag = "any"
+	return "{d}-{v}{b}-{py}-{a}-{p}.whl".format(
+		d=escape_filename_component(distribution),
+		v=escape_filename_component(version),
+		b=("-" + escape_filename_component(build_tag) if build_tag is not None else ""),
+		py=escape_filename_component(python_tag),
+		a=escape_filename_component(abi_tag),
+		p=escape_filename_component(platform_tag),
+		)
+
+
+def wheel_is_compatible(filename):
+	"""
+	Return True if the wheel is compatible, False otherwise.
+	"""
+	data = parse_wheel_name(filename)
+	if six.PY3:
+		if not data["python_tag"].startswith("py3"):
+			return False
+	else:
+		if not data["python_tag"].startswith("py3"):
+			return False
+	if data["abi_tag"].lower() != "none":
+		return False
+	if data["platform_tag"].lower() != "any":
+		return False
+	return True
+
+
+class BaseHandler(object):
+	"""
+	Baseclass for installation handlers.
+	"""
+	name = "<name not set>"
+	
+	def __init__(self, wheel, verbose=False):
+		self.wheel = wheel
+		self.verbose = verbose
+	
+	def copytree(self, src, dest):
+		"""copies a directory tree."""
+		if self.verbose:
+			print("Copying {s} -> {d}".format(s=src, d=dest))
+		if os.path.isfile(src):
+			i = shutil.copy(src, dest)
+			return i
+		else:
+			target = os.path.join(
+				dest,
+				os.path.basename(os.path.normpath(src)),
+				)
+			shutil.copytree(src, target)
+			return target
+	
+	@property
+	def distinfo_name(self):
+		"""the name of the *.dist-info directory."""
+		data = parse_wheel_name(self.wheel.filename)
+		return "{pkg}-{v}.dist-info".format(
+			pkg=data["distribution"],
+			v=data["version"],
+			)
+
+
+class TopLevelHandler(BaseHandler):
+	"""Handler for 'top_level.txt'"""
+	name = "top_level.txt installer"
+	
+	def handle_install(self, src, dest):
+		tltxtp = os.path.join(src, self.distinfo_name, "top_level.txt")
+		files_installed = []
+		with open(tltxtp, "r") as fin:
+			for pkg_name in fin:
+				pure = pkg_name.replace("\r", "").replace("\n", "")
+				p = self.copytree(os.path.join(src, pure), dest)
+				files_installed.append(p)
+		return files_installed
+
+
+class ConsoleScriptsHandler(BaseHandler):
+	"""Handler for 'console_scripts'."""
+	name = "console_scripts installer"
+	
+	def handle_install(self, src, dest):
+		eptxtp = os.path.join(src, self.distinfo_name, "entry_points.txt")
+		if not os.path.exists(eptxtp):
+			if self.verbose:
+				print("No entry_points.txt found, skipping.")
+			return
+		parser = configparser.read(eptxtp)
+		if not parser.has_section("console_scripts"):
+			if self.verbose:
+				print("No console_scripts definition found, skipping.")
+			return
+		
+		files_installed = []
+		
+		with open(src, self.distinfo_name, "metadata.json") as fin:
+			desc = json.load(fin).get("summary", "???")
+		
+		for command, definition in parser.items(section="console_scripts"):
+			name, loc = definition.replace(" ", "").split("=")
+			modname, funcname = loc.split(":")
+			if not name.endswith(".py"):
+				name += ".py"
+			path = create_command(
+				name,
+				(u"""'''%s'''
+from %s import %s
+
+if __name__ == "__main__":
+    %s()
+""" % (desc, modname, funcname, funcname)).encode("utf-8"))
+			files_installed.append(path)
+		return files_installed
+
+
+class WheelInfoHandler(BaseHandler):
+	"""Handler for wheel informations."""
+	name = "WHEEL information checker"
+	supported_major_versions = [1]
+	supported_versions = ["1.0"]
+	
+	def handle_install(self, src, dest):
+		wtxtp = os.path.join(src, self.distinfo_name, "WHEEL")
+		with open(wtxtp, "r") as fin:
+			for line in fin:
+				line = line.replace("\r", "").replace("\n", "")
+				ki = line.find(":")
+				key = line[:ki]
+				value = line[ki+2:]
+				
+				if key.lower() == "wheel-version":
+					major, minor = value.split(".")
+					major, minor = int(major), int(minor)
+					if major not in self.supported_major_versions:
+						raise WheelError("Wheel major version is incompatible!")
+					if value not in self.supported_versions:
+						print("WARNING: unsupported minor version: " + str(value))
+					self.wheel.version = (major, minor)
+				
+				elif key.lower() == "generator":
+					if self.verbose:
+						print("Wheel generated by: " + value)
+		return []
+
+
+class DependencyHandler(BaseHandler):
+	"""
+	Handler for the dependencies.
+	"""
+	name = "dependency handler"
+	
+	def handle_install(self, src, dest):
+		metap = os.path.join(src, self.distinfo_name, "metadata.json")
+		with open(metap, "r") as fin:
+			content = json.load(fin)
+		dependencies = content.get("run_requires", [{"requires": []}])[0]["requires"]
+		self.wheel.dependencies += dependencies
+	
+		
+# list of default handlers
+DEFAULT_HANDLERS = [
+	WheelInfoHandler,
+	DependencyHandler,
+	TopLevelHandler,
+	ConsoleScriptsHandler,
+	]
+
+
+class Wheel(object):
+	"""class for installing python wheels."""
+	def __init__(self, path, handlers=DEFAULT_HANDLERS, verbose=False):
+		self.path = path
+		self.verbose = True
+		self.filename = os.path.basename(self.path)
+		self.handlers = [handler(self, self.verbose) for handler in handlers]
+		self.version = None  # to be set by handler
+		self.dependencies = []  # to be set by handler
+		
+		if not wheel_is_compatible(self.filename):
+			raise WheelError("Incompatible wheel: {p}!".format(p=self.filename))
+		
+	def install(self, targetdir):
+		"""
+		Install the wheel into the target directory.
+		Return (files_installed, dependencies)
+		"""
+		if self.verbose:
+			print("Extracting wheel..")
+		tp = self.extract_into_temppath()
+		if self.verbose:
+			print("Extraction finished, running handlers...")
+		files_installed = []
+		for handler in self.handlers:
+			if hasattr(handler, "handle_install"):
+				if self.verbose:
+					print("Running handler '{h}'...".format(
+						h=getattr(handler, "name", "<unknown>"))
+						)
+				tfi = handler.handle_install(tp, targetdir)
+				if tfi is not None:
+					files_installed += tfi
+		if self.verbose:
+			print("Cleaning up...")
+		shutil.rmtree(tp)
+		return (files_installed, self.dependencies)
+	
+	def extract_into_temppath(self):
+		"""
+		Extract the wheel into a temporary directory.
+		Return the path of the temporary directory.
+		"""
+		p = os.path.join(tempfile.gettempdir(), "wheel_tmp", self.filename)
+		if not os.path.exists(p):
+			os.makedirs(p)
+		
+		with zipfile.ZipFile(self.path, mode="r") as zf:
+			zf.extractall(p)
+		
+		return p
+
+
+if __name__ == "__main__":
+	# test script
+	import sys
+	fi, dep = Wheel(sys.argv[1], verbose=True).install(os.path.expanduser("~/Documents/site-packages/"))
+	print("files installed: ")
+	print(fi)
+	print("dependencies:")
+	print(dep)

--- a/lib/stashutils/wheels.py
+++ b/lib/stashutils/wheels.py
@@ -115,11 +115,13 @@ class BaseHandler(object):
 		self.wheel = wheel
 		self.verbose = verbose
 	
-	def copytree(self, src, dest):
+	def copytree(self, src, dest, remove=False):
 		"""copies a directory tree."""
 		if self.verbose:
 			print("Copying {s} -> {d}".format(s=src, d=dest))
 		if os.path.isfile(src):
+			if os.path.exists(dest) and remove:
+				os.remove(dest)
 			i = shutil.copy(src, dest)
 			return i
 		else:
@@ -127,6 +129,8 @@ class BaseHandler(object):
 				dest,
 				os.path.basename(os.path.normpath(src)),
 				)
+			if os.path.exists(target) and remove:
+				shutil.rmtree(target)
 			shutil.copytree(src, target)
 			return target
 	
@@ -150,7 +154,7 @@ class TopLevelHandler(BaseHandler):
 		with open(tltxtp, "r") as fin:
 			for pkg_name in fin:
 				pure = pkg_name.replace("\r", "").replace("\n", "")
-				p = self.copytree(os.path.join(src, pure), dest)
+				p = self.copytree(os.path.join(src, pure), dest, remove=True)
 				files_installed.append(p)
 		return files_installed
 

--- a/lib/stashutils/wheels.py
+++ b/lib/stashutils/wheels.py
@@ -123,10 +123,12 @@ class BaseHandler(object):
 		if self.verbose:
 			print("Copying {s} -> {d}".format(s=src, d=dest))
 		if os.path.isfile(src):
+			if os.path.isdir(dest):
+				dest = os.path.join(dest, os.path.basename(src))
 			if os.path.exists(dest) and remove:
 				os.remove(dest)
-			i = shutil.copy(src, dest)
-			return i
+			shutil.copy(src, dest)
+			return dest
 		else:
 			target = os.path.join(
 				dest,
@@ -164,7 +166,7 @@ class TopLevelHandler(BaseHandler):
 					dp = os.path.join(dest, pure + ".py")
 					p = self.copytree(sp + ".py", dp, remove=True)
 				else:
-					raise WheelError("top_lehel.txt entry '{e}' not found in toplevel directory!".format(e=pure))
+					raise WheelError("top_level.txt entry '{e}' not found in toplevel directory!".format(e=pure))
 				files_installed.append(p)
 		return files_installed
 

--- a/lib/stashutils/wheels.py
+++ b/lib/stashutils/wheels.py
@@ -166,7 +166,13 @@ class ConsoleScriptsHandler(BaseHandler):
 				print("No entry_points.txt found, skipping.")
 			return
 		parser = configparser.ConfigParser()
-		parser.read(eptxtp)
+		try:
+			parser.read(eptxtp)
+		except configparser.MissingSectionHeaderError:
+			# print message and return
+			if self.verbose:
+				print("No section headers found in entry_points.txt, passing.")
+				return
 		if not parser.has_section("console_scripts"):
 			if self.verbose:
 				print("No console_scripts definition found, skipping.")
@@ -174,7 +180,8 @@ class ConsoleScriptsHandler(BaseHandler):
 		
 		files_installed = []
 		
-		with open(src, self.distinfo_name, "metadata.json") as fin:
+		mdp = os.path.join(src, self.distinfo_name, "metadata.json")
+		with open(mdp, "r") as fin:
 			desc = json.load(fin).get("summary", "???")
 		
 		for command, definition in parser.items(section="console_scripts"):

--- a/lib/stashutils/wheels.py
+++ b/lib/stashutils/wheels.py
@@ -197,8 +197,11 @@ class ConsoleScriptsHandler(BaseHandler):
 		files_installed = []
 		
 		mdp = os.path.join(src, self.distinfo_name, "metadata.json")
-		with open(mdp, "r") as fin:
-			desc = json.load(fin).get("summary", "???")
+		if os.path.exists(mdp):
+			with open(mdp, "r") as fin:
+				desc = json.load(fin).get("summary", "???")
+		else:
+			desc = "???"
 		
 		for command, definition in parser.items(section="console_scripts"):
 			# name, loc = definition.replace(" ", "").split("=")

--- a/lib/stashutils/wheels.py
+++ b/lib/stashutils/wheels.py
@@ -92,7 +92,10 @@ def wheel_is_compatible(filename):
 	Return True if the wheel is compatible, False otherwise.
 	"""
 	data = parse_wheel_name(filename)
-	if six.PY3:
+	if ("py2.py3" in data["python_tag"]) or ("py3.py2" in data["python_tag"]):
+		# only here to skip elif/else
+		pass
+	elif six.PY3:
 		if not data["python_tag"].startswith("py3"):
 			return False
 	else:
@@ -154,7 +157,14 @@ class TopLevelHandler(BaseHandler):
 		with open(tltxtp, "r") as fin:
 			for pkg_name in fin:
 				pure = pkg_name.replace("\r", "").replace("\n", "")
-				p = self.copytree(os.path.join(src, pure), dest, remove=True)
+				sp = os.path.join(src, pure)
+				if os.path.exists(sp):
+					p = self.copytree(sp, dest, remove=True)
+				elif os.path.exists(sp + ".py"):
+					dp = os.path.join(dest, pure + ".py")
+					p = self.copytree(sp + ".py", dp, remove=True)
+				else:
+					raise WheelError("top_lehel.txt entry '{e}' not found in toplevel directory!".format(e=pure))
 				files_installed.append(p)
 		return files_installed
 

--- a/tests/lib_stashutils/__init__.py
+++ b/tests/lib_stashutils/__init__.py
@@ -1,0 +1,3 @@
+"""dummy file."""
+pass
+

--- a/tests/lib_stashutils/test_wheels.py
+++ b/tests/lib_stashutils/test_wheels.py
@@ -1,0 +1,78 @@
+"""tests for the wheel-support"""
+import six
+
+from stashutils import wheels
+
+from stash.tests.stashtest import StashTestCase
+
+
+class WheelsTests(StashTestCase):
+    """tests fpr the wheel-support."""
+    def test_wheel_is_compatible(self):
+        """test wheel_is_compatible() result"""
+        wheelnamecompatibility = [
+            ("package-1.0.0-py2.py3-none-any.whl", True),  # full compatibility
+            ("package-1.0.0-2-py2.py3-none-any.whl", True),  # full compatible with build tag
+            ("package-1.0.0-py2-none-any.whl", not six.PY3),  # only py2 compatible
+            ("package-1.0.0-py3-none-any.whl", six.PY3),  # only py3 compatible
+            ("package-1.0.0-py2.py3-cp33m-any.whl", False),  # incompatible abi-tag
+            ("package-1.0.0-py2.py3-none-linux_x86_64.whl", False),  # incompatible platform tag
+            ("package-1.0.0-py2.py3-cp33m-linux_x86_64.whl", False),  # incompatible abi and platform tags
+            ("package-1.0.0-cpy2-none-any.whl", False),  # cpython 2 incompatibility
+            ("package-1.0.0-cpy3-none-any.whl", False),  # cpython 3 incompatibility
+        ]
+        for wheelname, is_compatible in wheelnamecompatibility:
+            ic = wheels.wheel_is_compatible(wheelname)
+            self.assertEqual(ic, is_compatible)
+
+    def test_wheel_is_compatible_raises(self):
+        """test wheel_is_compatible() error handling"""
+        wrong_wheelnames = [
+            "nonwheel-1.0.0-py2.py3-none-any.txt",
+            "noabi-1.0.0-py2.py3-any.whl",
+            "toomany-1.0.0.-py2.py3-none-any-extra-fields.whl",
+        ]
+        for wheelname in wrong_wheelnames:
+            try:
+                wheels.wheel_is_compatible(wheelname)
+            except wheels.WheelError:
+                pass
+            else:
+                raise AssertionError("wheels.wheel_is_compatible() did not raise WheelError when required.")
+
+    def test_parse_wheel_name(self):
+        """test parse_wheel_name()"""
+        name1 = "distribution-version-buildtag-pythontag-abitag-platformtag.whl"
+        result1 = wheels.parse_wheel_name(name1)
+        expected1 = {
+            "distribution": "distribution",
+            "version": "version",
+            "build_tag": "buildtag",
+            "python_tag": "pythontag",
+            "abi_tag": "abitag",
+            "platform_tag": "platformtag",
+        }
+        self.assertEqual(result1, expected1)
+
+        name2 = "stashutils-0.7.0-py2.py3-none-any.whl"
+        result2 = wheels.parse_wheel_name(name2)
+        expected2 = {
+            "distribution": "stashutils",
+            "version": "0.7.0",
+            "build_tag": None,
+            "python_tag": "py2.py3",
+            "abi_tag": "none",
+            "platform_tag": "any",
+        }
+        self.assertEqual(result2, expected2)
+
+    def test_generate_filename(self):
+        """test generate_filename()"""
+        data = {
+            "distribution": "somepackage",
+            "version": "1.0.0",
+            "python_tag": "py27",
+        }
+        expected = "somepackage-1.0.0-py27-none-any.whl"
+        result = wheels.generate_filename(**data)
+        self.assertEqual(result, expected)

--- a/tests/lib_stashutils/test_wheels.py
+++ b/tests/lib_stashutils/test_wheels.py
@@ -1,8 +1,6 @@
 """tests for the wheel-support"""
 import six
 
-from stashutils import wheels
-
 from stash.tests.stashtest import StashTestCase
 
 
@@ -10,6 +8,8 @@ class WheelsTests(StashTestCase):
     """tests fpr the wheel-support."""
     def test_wheel_is_compatible(self):
         """test wheel_is_compatible() result"""
+        from stashutils import wheels
+
         wheelnamecompatibility = [
             ("package-1.0.0-py2.py3-none-any.whl", True),  # full compatibility
             ("package-1.0.0-2-py2.py3-none-any.whl", True),  # full compatible with build tag
@@ -27,6 +27,8 @@ class WheelsTests(StashTestCase):
 
     def test_wheel_is_compatible_raises(self):
         """test wheel_is_compatible() error handling"""
+        from stashutils import wheels
+
         wrong_wheelnames = [
             "nonwheel-1.0.0-py2.py3-none-any.txt",
             "noabi-1.0.0-py2.py3-any.whl",
@@ -42,6 +44,8 @@ class WheelsTests(StashTestCase):
 
     def test_parse_wheel_name(self):
         """test parse_wheel_name()"""
+        from stashutils import wheels
+
         name1 = "distribution-version-buildtag-pythontag-abitag-platformtag.whl"
         result1 = wheels.parse_wheel_name(name1)
         expected1 = {
@@ -68,6 +72,8 @@ class WheelsTests(StashTestCase):
 
     def test_generate_filename(self):
         """test generate_filename()"""
+        from stashutils import wheels
+
         data = {
             "distribution": "somepackage",
             "version": "1.0.0",

--- a/tests/pip/test_pip.py
+++ b/tests/pip/test_pip.py
@@ -105,6 +105,7 @@ class PipTests(StashTestCase):
             raise AssertionError("Could not import installed module: " + repr(e))
 
     @requires_network
+    @expected_failure_on_py3
     def test_install_pypi_complex_1(self):
         """test 'pip install <pypi_package>' with a complex package."""
         output = self.run_command("pip --verbose install twisted", exitcode=0)


### PR DESCRIPTION
Hi,
this is a small PR for adding basic wheel support to `pip`.
The support for wheels was requested by @scottamuss in Issue #278 and some others on the forums.
Since wheels do not require `setuptools` for installation, this should pip support for package.

New `pip`-behavior:
- `pip install` tries to install a wheel if a compatible wheel is found, otherwise attempts to download normal source and run `setup.py` normally.
- `pip download` tries to download `.tar.gz`  if possible, but falls back to a compatible `.whl` if no other file was found.
- `pip install` will now ignore `package already installed`-errors during dependency installation.

The changes should be working properly, but if anyone is interested in helping me testing these changes, please do so :wink:.