### PR TITLE
 Fixed issue #330: fail on non-ascii

### DIFF
--- a/bin/cat.py
+++ b/bin/cat.py
@@ -25,7 +25,8 @@ def main(args):
 
     fileinput.close()  # in case it is not closed
     try:
-        for line in fileinput.input(ns.files):
+        for line in fileinput.input(ns.files, 
+                                    openhook=fileinput.hook_encoded("utf-8")):
             print(filter_non_printable(line), end='')
     except Exception as e:
         print('cat: %s' % str(e))

--- a/bin/grep.py
+++ b/bin/grep.py
@@ -30,7 +30,7 @@ def main(args):
 
     fileinput.close()  # in case it is not closed
     try:
-        for line in fileinput.input(files):
+        for line in fileinput.input(files, openhook=fileinput.hook_encoded("utf-8")):
             if bool(pattern.search(line)) != ns.invert:
                 if ns.invert: # optimize: if ns.invert, then no match, so no highlight color needed
                     newline = line

--- a/bin/grep.py
+++ b/bin/grep.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 
 import argparse
+import collections
 import fileinput
 import os
 import re
@@ -17,6 +18,8 @@ def main(args):
                     help='ignore case while searching')
     ap.add_argument('-v', '--invert', action='store_true',
                     help='invert the search result')
+    ap.add_argument('-c', '--count', action='store_true',
+                    help='count the search results instead of normal output')
     ns = ap.parse_args(args)
 
     flags = 0
@@ -30,8 +33,12 @@ def main(args):
 
     fileinput.close()  # in case it is not closed
     try:
+        counts = collections.defaultdict(int)
         for line in fileinput.input(files, openhook=fileinput.hook_encoded("utf-8")):
             if bool(pattern.search(line)) != ns.invert:
+              if ns.count:
+                    count[fileinput.filename()] += 1
+              else:
                 if ns.invert: # optimize: if ns.invert, then no match, so no highlight color needed
                     newline = line
                 else:
@@ -44,6 +51,12 @@ def main(args):
                 print(fmt.format(filename=fileinput.filename(),
                                  lineno=fileinput.filelineno(),
                                  line=newline.rstrip()))
+                
+        if ns.count:
+            for filename, count in counts.items():
+                fmt = u'{count:6} {filename}'
+                print(fmt.format(filename=filename, count=count))
+                
     except Exception as err:
         print("grep: {}: {!s}".format(type(err).__name__, err), file=sys.stderr)
     finally:

--- a/bin/grep.py
+++ b/bin/grep.py
@@ -37,7 +37,7 @@ def main(args):
         for line in fileinput.input(files, openhook=fileinput.hook_encoded("utf-8")):
             if bool(pattern.search(line)) != ns.invert:
               if ns.count:
-                    count[fileinput.filename()] += 1
+                    counts[fileinput.filename()] += 1
               else:
                 if ns.invert: # optimize: if ns.invert, then no match, so no highlight color needed
                     newline = line

--- a/bin/head.py
+++ b/bin/head.py
@@ -59,7 +59,7 @@ def main(args):
                     print(header_fmt.format(fname), end='')
 
             fileinput.close()
-            inp = fileinput.input(fname)
+            inp = fileinput.input(fname, openhook=fileinput.hook_encoded("utf-8"))
             if ns.lines >= 0:
                 buf = []
                 for i, line in enumerate(inp):
@@ -70,7 +70,7 @@ def main(args):
                     print(line, end='')
             else:
                 buf = []
-                for line in fileinput.input(inp):
+                for line in fileinput.input(inp, openhook=fileinput.hook_encoded("utf-8")):
                     buf.append(line)
                     if len(buf) > -ns.lines:
                         del buf[0]

--- a/bin/more.py
+++ b/bin/more.py
@@ -27,7 +27,7 @@ def more(filenames, pagesize=10, clear=False, fmt='{line}'):
         pageno = 1
         if clear:
             clear_screen()
-        for line in fileinput.input(filenames):
+        for line in fileinput.input(filenames, openhook=fileinput.hook_encoded("utf-8")):
             lineno, filename, filelineno = fileinput.lineno(), fileinput.filename(), fileinput.filelineno()
             print(fmt.format(**locals()), end='')
             if pagesize and lineno % pagesize == 0:

--- a/bin/pbcopy.py
+++ b/bin/pbcopy.py
@@ -15,7 +15,7 @@ def main(args):
     
     fileinput.close() # in case it is not closed
     try:
-        clipboard.set(''.join(line for line in fileinput.input(ns.file)))
+        clipboard.set(''.join(line for line in fileinput.input(ns.file, openhook=fileinput.hook_encoded("utf-8"))))
     except Exception as err:
         print("pbcopy: {}: {!s}".format(type(err).__name__, err), file=sys.stderr)
     finally:

--- a/bin/sort.py
+++ b/bin/sort.py
@@ -24,7 +24,7 @@ def main(args):
     fileinput.close()  # in case it is not closed
     try:
         lines = None
-        for line in fileinput.input(ns.files):
+        for line in fileinput.input(ns.files, openhook=fileinput.hook_encoded("utf-8")):
             if fileinput.isfirstline():
                 _print(lines)
                 lines = []

--- a/bin/uniq.py
+++ b/bin/uniq.py
@@ -19,7 +19,7 @@ def main(args):
     try:
         prev_line = None
         lines = None
-        for line in fileinput.input(ns.files):
+        for line in fileinput.input(ns.files, openhook=fileinput.hook_encoded("utf-8")):
             if fileinput.isfirstline():
                 _print(lines)
                 lines = []


### PR DESCRIPTION
changed `fileinput` from implicit `ascii` encoding to explicit `utf-8` to allow `unicode` input
also added `--count` option to `grep`