### PR TITLE
Fix broken Text- & Backgroundcolor

### DIFF
--- a/system/dummyobjc_util.py
+++ b/system/dummyobjc_util.py
@@ -50,6 +50,10 @@ class UIColor(ObjCClass):
         pass
 
     @classmethod
+    def grayColor(cls):
+        pass
+
+    @classmethod
     def yellowColor(cls):
         pass
 

--- a/system/shscreens.py
+++ b/system/shscreens.py
@@ -30,13 +30,15 @@ BlackColor = UIColor.blackColor()
 RedColor = UIColor.redColor()
 GreenColor = UIColor.greenColor()
 BrownColor = UIColor.brownColor()
-# BlueColor = UIColor.blueColor()
-BlueColor = UIColor.colorWithRed_green_blue_alpha_(0.3, 0.3, 1.0, 1.0)
+BlueColor = UIColor.blueColor()
+# BlueColor = UIColor.colorWithRed_green_blue_alpha_(0.3, 0.3, 1.0, 1.0)
 MagentaColor = UIColor.magentaColor()
 CyanColor = UIColor.cyanColor()
 WhiteColor = UIColor.whiteColor()
-GrayColor = UIColor.colorWithRed_green_blue_alpha_(0.5, 0.5, 0.5, 1.0)
+GrayColor = UIColor.grayColor()
+# GrayColor = UIColor.colorWithRed_green_blue_alpha_(0.5, 0.5, 0.5, 1.0)
 YellowColor = UIColor.yellowColor()
+# SmokeColor = UIColor.smokeColor()
 SmokeColor = UIColor.colorWithRed_green_blue_alpha_(0.8, 0.8, 0.8, 1.0)
 
 
@@ -636,6 +638,10 @@ class ShSequentialRenderer(object):
         self.logger = logging.getLogger('StaSh.SequentialRenderer')
         self.last_rendered_time = 0
         self.render_thread = None
+        
+        # update default colors to match terminal
+        self.FG_COLORS["default"] = self.FG_COLORS.get(self.terminal.text_color, WhiteColor)
+        self.BG_COLORS["default"] = self.BG_COLORS.get(self.terminal.background_color, BlackColor)
 
     @staticmethod
     def _same_style(char1, char2):

--- a/system/shterminal.py
+++ b/system/shterminal.py
@@ -275,7 +275,8 @@ class ShTerminal(object):
     @background_color.setter
     @on_main_thread
     def background_color(self, value):
-        r, g, b = self._background_color = value
+        self._background_color = value
+        r, g, b, a = ui.parse_color(value)
         self.tvo.setBackgroundColor_(UIColor.colorWithRed_green_blue_alpha_(r, g, b, 1))
 
     @property
@@ -309,7 +310,8 @@ class ShTerminal(object):
     @text_color.setter
     @on_main_thread
     def text_color(self, value):
-        r, g, b = self._text_color = value
+        self._text_color = value
+        r, g, b, a = ui.parse_color(value)
         self.tvo.setTextColor_(UIColor.colorWithRed_green_blue_alpha_(r, g, b, 1))
 
     @property
@@ -319,7 +321,8 @@ class ShTerminal(object):
     @tint_color.setter
     @on_main_thread
     def tint_color(self, value):
-        r, g, b = self._tint_color = value
+        self._tint_color = value
+        r, g, b, a = ui.parse_color(value)
         self.tvo.setTintColor_(UIColor.colorWithRed_green_blue_alpha_(r, g, b, 1))
 
     @property

--- a/tests/pip/test_pip.py
+++ b/tests/pip/test_pip.py
@@ -69,7 +69,7 @@ class PipTests(StashTestCase):
         output = self.run_command("pip search pytest", exitcode=0)
         self.assertIn("pytest", output)
         self.assertIn("pytest-translations", output)
-        self.assertIn("pytest-env", output)
+        self.assertIn("pytest-socket", output)
 
     @requires_network
     def test_versions(self):

--- a/tests/pip/test_pip.py
+++ b/tests/pip/test_pip.py
@@ -68,7 +68,7 @@ class PipTests(StashTestCase):
         """test 'pip search <term>'"""
         output = self.run_command("pip search pytest", exitcode=0)
         self.assertIn("pytest", output)
-        self.assertIn("pytest-faker", output)
+        self.assertIn("pytest-translations", output)
         self.assertIn("pytest-env", output)
 
     @requires_network

--- a/tests/pip/test_pip.py
+++ b/tests/pip/test_pip.py
@@ -68,7 +68,7 @@ class PipTests(StashTestCase):
         """test 'pip search <term>'"""
         output = self.run_command("pip search pytest", exitcode=0)
         self.assertIn("pytest", output)
-        self.assertIn("pytest-cov", output)
+        self.assertIn("pytest-faker", output)
         self.assertIn("pytest-env", output)
 
     @requires_network


### PR DESCRIPTION
After two years, I finally found the bug!
As mentioned in PR #207, the backgroundcolor (and textcolor) system was broken. When using non-black background-colors, the background would have the correct color, but the text would always have black background and white text.
This PR fixes this bug, but reduces the color range for the terminal from full RGB to the colors specified in `$STASH_ROOT/system/shscreens.py` (excluding `smoke`). Additionally, the values of some colors have been adjusted to match the terminal backgroundcolors.

**Fixes:**
- fix background and text colors
- fix tests for pip search (but will most likely break again in the future)

**Improvements:**
- `easy_config.py` was updated to reflect these changes
- `easy_config.py` will now report `$SELFUPDATE_TARGET`.
- The `.stash_config` files now accept all values which would be accepted by the `ui`-module. However, these would only work on the actual background and not on the text, so you should use strings instead (e.g. `"red"`).