### PR TITLE
Fix bug in pip wheel installation; Fix test for 'pip search'

### DIFF
--- a/lib/stashutils/wheels.py
+++ b/lib/stashutils/wheels.py
@@ -118,8 +118,18 @@ class BaseHandler(object):
 		self.wheel = wheel
 		self.verbose = verbose
 	
-	def copytree(self, src, dest, remove=False):
-		"""copies a directory tree."""
+	def copytree(self, packagepath, src, dest, remove=False):
+		"""
+		Copies a package directory tree.
+		:param packagepath: relative path of the (sub-)package, e.g. 'package/subpackage/'
+		:type packagepath: str
+		:param src: path to the actual source of the root package
+		:type src: str
+		:param dest: path to copy to
+		:type dest: str
+		:return: the path to which the directories have been copied.
+		:trype: str
+		"""
 		if self.verbose:
 			print("Copying {s} -> {d}".format(s=src, d=dest))
 		if os.path.isfile(src):
@@ -132,7 +142,8 @@ class BaseHandler(object):
 		else:
 			target = os.path.join(
 				dest,
-				os.path.basename(os.path.normpath(src)),
+				# os.path.basename(os.path.normpath(src)),
+				packagepath,
 				)
 			if os.path.exists(target) and remove:
 				shutil.rmtree(target)
@@ -161,10 +172,10 @@ class TopLevelHandler(BaseHandler):
 				pure = pkg_name.replace("\r", "").replace("\n", "")
 				sp = os.path.join(src, pure)
 				if os.path.exists(sp):
-					p = self.copytree(sp, dest, remove=True)
+					p = self.copytree(pure, sp, dest, remove=True)
 				elif os.path.exists(sp + ".py"):
 					dp = os.path.join(dest, pure + ".py")
-					p = self.copytree(sp + ".py", dp, remove=True)
+					p = self.copytree(pure, sp + ".py", dp, remove=True)
 				else:
 					raise WheelError("top_level.txt entry '{e}' not found in toplevel directory!".format(e=pure))
 				files_installed.append(p)

--- a/tests/pip/test_pip.py
+++ b/tests/pip/test_pip.py
@@ -68,8 +68,10 @@ class PipTests(StashTestCase):
         """test 'pip search <term>'"""
         output = self.run_command("pip search pytest", exitcode=0)
         self.assertIn("pytest", output)
-        self.assertIn("pytest-translations", output)
-        self.assertIn("pytest-socket", output)
+        # due to changing pypi search results, the following results are not guaranteed.
+        # TODO: fix this
+        # self.assertIn("pytest-cov", output)
+        # self.assertIn("pytest-env", output)
 
     @requires_network
     def test_versions(self):


### PR DESCRIPTION
Hi,

this PR fixes the broken test for `pip search` (as written in #347).
I already tried to fix it previously, but apparently pypi search results vary from time to time. Before this change, the test expected `pip search pytest` to print `pytest`, `pytest-translations` and `pytest-socket`. Now it only expects `pytest`.

This PR also fixes a bug in the `pip install` wheel logic. There was a bug that for some packages, all subpackages (e.g. `mypackage.subpackages`) would be installed directly in `site-packages-*` instead of their parent package. This should now be fixed.  See [this forum thread](https://forum.omz-software.com/topic/5340/pythonista-3-stash-plotly-i-m-close-to-a-meltdown) for details.

