### PR TITLE
Support multiple -H commands in curl.py to build composite request

### DIFF
--- a/bin/curl.py
+++ b/bin/curl.py
@@ -17,15 +17,15 @@ def main(args):
     ap.add_argument('-o', '--output-file', help='write output to file instead of stdout')
     ap.add_argument('-X', '--request-method', default='GET', choices=['GET', 'POST', 'HEAD'],
                     help='specify request method to use (default to GET)')
-    ap.add_argument('-H', '--header', help='Custom header to pass to server (H)')
+    ap.add_argument('-H', '--header', help='Custom header to pass to server (H)', action='append')
     ap.add_argument('-d', '--data', help='HTTP POST data (H)')
 
     ns = ap.parse_args(args)
     url = ns.url or clipboard.get()
 
     headers = {}
-    if ns.header:
-        for h in ns.header.split(';'):
+    for header in ns.header:
+        for h in header.split(';'):
             name, value = h.split(':')
             headers[name.strip()] = value.strip()
 


### PR DESCRIPTION
Right now curl.py is not compatible with curl when there are multiple -H commands, as only the last one is used.  This fixes that, so -H commands build a composite set of headers, as is the typical use case.