### PR TITLE
various improvements and bugfixes for pip and gh

### DIFF
--- a/bin/gh.py
+++ b/bin/gh.py
@@ -15,68 +15,47 @@ NOTE: assumes a keychain user/pass stored in 	keychainservice='stash.git.github.
 from __future__ import print_function
 import os
 import sys
+from functools import wraps
 
 from six.moves import input
 
 
-def install_module_from_github(username, package_name, folder, version):
-    """
-    Install python module from github zip files
-    """
-    cmd_string = """
-        echo Installing {1} {3} ...
-        wget https://github.com/{0}/{1}/archive/{3}.zip -o $TMPDIR/{1}.zip
-        mkdir $TMPDIR/{1}_src
-        unzip $TMPDIR/{1}.zip -d $TMPDIR/{1}_src
-        rm -f $TMPDIR/{1}.zip
-        mv $TMPDIR/{1}_src/{2} $STASH_ROOT/lib/
-        rm -rf $TMPDIR/{1}_src
-        echo Done
-        """.format(username,
-                   package_name,folder,
-                   version
-                   )
-    globals()['_stash'](cmd_string)
+_stash = globals()["_stash"]
 
 
 try:
-    libpath=os.path.join(os.environ['STASH_ROOT'] ,'lib')
-    if not libpath in sys.path:
-        sys.path.insert(1,libpath)
     import github
 except ImportError:
-    print('no github found in ',libpath)
-    install_module_from_github('pygithub', 'pygithub', 'github','master')
+    print("Could not import 'github', installing it...")
+    _stash("pip install pygithub")
     import github
 try: 
-	import docopt
+    import docopt
 except  ImportError:
-	install_module_from_github('docopt','docopt','docopt.py','master')
+    print("Could not import 'docopt', installing it...")
+    _stash("pip install docopt")
 from docopt import docopt
 from github import Github
-import keychain,console,inspect
+import keychain, console, inspect
+
 
 class GitHubRepoNotFoundError(Exception):
 	pass
 
-
-from functools import wraps
 
 def command(func):
     @wraps(func)
     def tmp(argv):
        if len(argv)==1:
          if func.__name__ not in ['gh_list_keys']:
-         	argv.append('--help')
+             argv.append('--help')
        try:
-       	 args=docopt(func.__doc__,argv=argv)
-       	 return func(args)
+           args=docopt(func.__doc__,argv=argv)
+           return func(args)
        except SystemExit as e:
-       	print(e)
+           print(e)
 
     return tmp
-
-
 
 
 @command
@@ -233,7 +212,7 @@ Examples:
 			echo ssh-keygen -d rsa -b2048
 			ssh-keygen -trsa -b2048
 			'''
-			globals()['_stash'](cmd_string)
+			_stash(cmd_string)
 		args['<public_key_path>']=default_keyfile
 	#if private key, use pub key
 	if not args['<public_key_path>'].endswith('.pub'):

--- a/bin/pip.py
+++ b/bin/pip.py
@@ -1128,7 +1128,7 @@ class PyPIRepository(PackageRepository):
             else:
                 raise PipError('Version not found: {}{}'.format(pkg_name, ver_spec))
 
-    def _releases_matches_py_version(self, pkg_data, release):
+    def _release_matches_py_version(self, pkg_data, release):
         """
         Check if a release is compatible with the python version.
         :param pkg_data: package information

--- a/bin/pip.py
+++ b/bin/pip.py
@@ -1053,7 +1053,14 @@ class PyPIRepository(PackageRepository):
             if self.verbose:
                 print("No source distribution found, but a binary distribution was found and will be used.")
             target = wheel
-        else:
+
+        if target is None:
+            if self.verbose:
+                print("No allowed distribution found!")
+                if wheel is not None and (dist & DIST_ALLOW_WHL == 0):
+                    print("However, a wheel is available. Maybe try without '--no-binary' or with '--only-binary :all:'?")
+                if source is not None and (dist & DIST_ALLOW_SRC == 0):
+                    print("However, a source distribution is available. Maybe try with '--no-binary :all:'?")
             raise PipError("No allowed distribution found for '{}': {}!".format(pkg_name, hit))
 
         pkg_info = self._package_info(pkg_data)

--- a/bin/pip.py
+++ b/bin/pip.py
@@ -1030,23 +1030,31 @@ class PyPIRepository(PackageRepository):
                 if wheel_is_compatible(fn):
                     wheel = download
 
-        #raise PipError('Source distribution not available for {}: {}'.format(pkg_name, hit))
-        # source = wheel
         target = None
         if source is not None and (dist & DIST_ALLOW_SRC > 0):
             # source is available and allowed
             if (wheel is None) or (dist & DIST_PREFER_SRC > 0):
                 # no wheel is available or source is prefered
                 # use source
+                if self.verbose:
+                    print("A source distribution is available and will be used.")
                 target = source
-            elif (dist & DIST_ALLOW_SRC > 0):
+            elif (dist & DIST_ALLOW_WHL > 0):
                 # a wheel is available and allowed and source is not preffered
                 # use wheel
+                if self.verbose:
+                    print("A binary distribution is available and will be used.")
                 target = wheel
-        elif wheel is not None and (dist & DIST_ALLOW_WHL):
+            else:
+                raise PipError("No allowed distribution found for '{}': {}!".format(pkg_name, hit))
+        elif wheel is not None and (dist & DIST_ALLOW_WHL > 0):
             # source is not available or allowed, but a wheel is available and allowed
             # use wheel
+            if self.verbose:
+                print("No source distribution found, but a binary distribution was found and will be used.")
             target = wheel
+        else:
+            raise PipError("No allowed distribution found for '{}': {}!".format(pkg_name, hit))
 
         pkg_info = self._package_info(pkg_data)
         pkg_info['url'] = 'pypi'

--- a/bin/pip.py
+++ b/bin/pip.py
@@ -772,7 +772,9 @@ if __name__ == "__main__":
         Get AST of the setup file and also transform it for fake setuptools
         and stub setup calls.
         """
-        with codecs.open(filename, mode="r", encoding="UTF-8") as ins:
+        # with codecs.open(filename, mode="r", encoding="UTF-8") as ins:
+        #    s = ins.read()
+        with open(filename, "r") as ins:
             s = ins.read()
         tree = ast.parse(s, filename=filename, mode='exec')
         ArchiveFileInstaller.SetupTransformer().visit(tree)

--- a/bin/pip.py
+++ b/bin/pip.py
@@ -28,6 +28,7 @@ import requests
 import re
 import operator
 import traceback
+import platform
 
 import six
 from distutils.util import convert_path
@@ -1146,7 +1147,7 @@ class PyPIRepository(PackageRepository):
                 reqs = "python" + requires_python
                 name, ver_spec = VersionSpecifier.parse_requirement(reqs)
                 assert name == "python"  # if this if False some large bug happened...
-                if all([op(hit, ver) for op, ver in ver_spec.specs]):
+                if all([op(platform.python_version(), ver) for op, ver in ver_spec.specs]):
                     # compatible
                     return True
             else:

--- a/bin/pip.py
+++ b/bin/pip.py
@@ -1397,6 +1397,7 @@ if __name__ == '__main__':
                 if ns.nobinary == ":all:":
                     # disable all binaries
                     dist = dist & ~DIST_ALLOW_WHL
+                    dist = dist & ~DIST_PREFER_WHL
                 elif ns.nobinary == ":none:":
                     # allow all binaries
                     dist = dist | DIST_ALLOW_WHL
@@ -1408,6 +1409,8 @@ if __name__ == '__main__':
                 if ns.onlybinary == ":all:":
                     # disable all source
                     dist = dist & ~DIST_ALLOW_SRC
+                    dist = dist & ~DIST_PREFER_SRC
+
                 elif ns.nobinary == ":none:":
                     # allow all source
                     dist = dist | DIST_ALLOW_SRC

--- a/bin/pip.py
+++ b/bin/pip.py
@@ -383,7 +383,8 @@ def sort_versions(versionlist):
                     a = 0
                 else:
                     a = int(a)
-            ret.append((a, b))
+            # ret.append((a, b))
+            ret.append(a)  # TODO: replace with above line. There still seem to be some issues with the order of versions containing non-digits.
         return tuple(ret)
     return sorted(versionlist, key=sortf, reverse=True)
 
@@ -896,27 +897,27 @@ class PackageRepository(object):
         self.config.add_module(pkg_info)
         print('Package installed: {}'.format(pkg_name))
 
-        for pkg_name, ver_spec in name_versions:
+        for dep_name, ver_spec in name_versions:
 
-            if pkg_name == 'setuptools':  # do not install setuptools
+            if dep_name == 'setuptools':  # do not install setuptools
                 continue
 
             # Some packages have error on dependency names
-            pkg_name = PACKAGE_NAME_FIXER.get(pkg_name, pkg_name)
+            dep_name = PACKAGE_NAME_FIXER.get(dep_name, dep_name)
 
             # If this dependency is installed before, skipping
-            if pkg_name in sys.modules['setuptools']._installed_requirements_:
-                print('Dependency already installed: {}'.format(pkg_name))
+            if dep_name in sys.modules['setuptools']._installed_requirements_:
+                print('Dependency already installed: {}'.format(dep_name))
                 continue
 
-            if pkg_name in PYTHONISTA_BUNDLED_MODULES:
-                print('Dependency available in Pythonista bundle : {}'.format(pkg_name))
+            if dep_name in PYTHONISTA_BUNDLED_MODULES:
+                print('Dependency available in Pythonista bundle : {}'.format(dep_name))
                 continue
 
-            print('Installing dependency: {}'.format('{}{}'.format(pkg_name, ver_spec if ver_spec else '')))
-            repository = get_repository(pkg_name, verbose=self.verbose)
+            print('Installing dependency: {} (required by: {})'.format('{}{}'.format(dep_name, ver_spec if ver_spec else ''), pkg_name))
+            repository = get_repository(dep_name, verbose=self.verbose)
             try:
-                repository.install(pkg_name, ver_spec, dist=dependency_dist)
+                repository.install(dep_name, ver_spec, dist=dependency_dist)
             except PackageAlreadyInstalled:
                 # well, it is already installed...
                 # TODO: maybe update package if required?

--- a/bin/pip.py
+++ b/bin/pip.py
@@ -1033,7 +1033,7 @@ class PyPIRepository(PackageRepository):
         target = None
         if source is not None and (dist & DIST_ALLOW_SRC > 0):
             # source is available and allowed
-            if (wheel is None or (dist & DIST_ALLOW_SRC == 0)) or (dist & DIST_PREFER_SRC > 0):
+            if (wheel is None or (dist & DIST_ALLOW_WHL == 0)) or (dist & DIST_PREFER_SRC > 0):
                 # no wheel is available or source is prefered
                 # use source
                 if self.verbose:

--- a/bin/pip.py
+++ b/bin/pip.py
@@ -1033,7 +1033,7 @@ class PyPIRepository(PackageRepository):
         target = None
         if source is not None and (dist & DIST_ALLOW_SRC > 0):
             # source is available and allowed
-            if (wheel is None) or (dist & DIST_PREFER_SRC > 0):
+            if (wheel is None or (dist & DIST_ALLOW_SRC == 0)) or (dist & DIST_PREFER_SRC > 0):
                 # no wheel is available or source is prefered
                 # use source
                 if self.verbose:

--- a/bin/pip.py
+++ b/bin/pip.py
@@ -1332,7 +1332,7 @@ if __name__ == '__main__':
         "--prefer-binary",
         action="store_true",
         help="Prefer older binary packages over newer source packages",  # TODO: do we actually check older sources/wheels?
-        dest="prerferbinary",
+        dest="preferbinary",
     )
 
     download_parser = subparsers.add_parser('download', help='download packages')

--- a/bin/pip.py
+++ b/bin/pip.py
@@ -1045,8 +1045,6 @@ class PyPIRepository(PackageRepository):
                 if self.verbose:
                     print("A binary distribution is available and will be used.")
                 target = wheel
-            else:
-                raise PipError("No allowed distribution found for '{}': {}!".format(pkg_name, hit))
         elif wheel is not None and (dist & DIST_ALLOW_WHL > 0):
             # source is not available or allowed, but a wheel is available and allowed
             # use wheel

--- a/bin/pip.py
+++ b/bin/pip.py
@@ -1138,27 +1138,28 @@ class PyPIRepository(PackageRepository):
         :return: whether dist allows the release or not
         :rtype: boolean
         """
-        had_hit = False
+        had_v = False
         downloads = self._package_downloads(pkg_data, release)
         for download in downloads:
             pv = download.get("python_version", None)
-            if pt is None:
+            if pv is None:
                 continue
-            elif pt in ("py2.py3", "py3.py2"):
+            elif pv in ("py2.py3", "py3.py2"):
                 # compatible with both py versions
                 return True
-            elif pt.startswith("2")):
+            elif pv.startswith("2"):
                 # py2 release
                 if not six.PY3:
                     return True
-            elif pt.startswith("3"):
+            elif pv.startswith("3"):
                 # py3 release
                 if six.PY3:
                     return True
-            elif pt == "source":
+            elif pv == "source":
                 # i honestly have no idea what this means
                 # i assume it means "this source is compatible with both", so just return True
                 return True
+            had_v = True
         if had_v:
             # no allowed downloads found
             return False

--- a/bin/pip.py
+++ b/bin/pip.py
@@ -1183,7 +1183,7 @@ class PyPIRepository(PackageRepository):
         """
         downloads = self._package_downloads(pkg_data, release)
         for download in downloads:
-            pt = download.get("package_type", None)
+            pt = download.get("packagetype", None)
             if pt is None:
                 continue
             elif pt in ("source", "sdist"):

--- a/bin/pip.py
+++ b/bin/pip.py
@@ -366,12 +366,18 @@ def sort_versions(versionlist):
         splitted = e.split(".")
         ret = []
         for v in splitted:
-            try:
-                v = int(v)
-            except ValueError:
-                # non-int. Some versions contain letters, like "1.2.3d"
-                pass
-            ret.append(v)
+            # some versions may contain a string
+            # in py3, comparsion between int and str is no longer possible :(
+            # thus we instead sort by a tuple of (int, str), where str is the non-digt part of the version
+            s = re.search("[^0-9]", v)
+            if s is None:
+                # only numbers
+                a, b = int(v), ""
+            else:
+                # contains non-digits
+                i = s.start()
+                a, b = int(v[:i]), v[i:]
+            ret.append((a, b))
         return tuple(ret)
     return sorted(versionlist, key=sortf, reverse=True)
 

--- a/bin/pip.py
+++ b/bin/pip.py
@@ -1132,7 +1132,7 @@ class PyPIRepository(PackageRepository):
                 # version is allowed
                 return hit
         else:
-            raise PipError('Version not found: {}{}'.format(pkg_name, ver_spec))
+            raise PipError('Version not found: {}{}'.format(pkg_name, ver_spec if ver_spec is not None else ""))
 
     def _release_matches_py_version(self, pkg_data, release):
         """

--- a/bin/pip.py
+++ b/bin/pip.py
@@ -1016,6 +1016,9 @@ class PyPIRepository(PackageRepository):
         pkg_data = self._package_data(pkg_name)
         hit = self._determin_hit(pkg_data, ver_spec, dist=dist)
 
+        if self.verbose:
+            print("Using {n}=={v}...".format(n=pkg_name, v=hit))
+
         downloads = self._package_downloads(pkg_data, hit)
 
         if not downloads:

--- a/bin/pip.py
+++ b/bin/pip.py
@@ -878,7 +878,7 @@ class PackageRepository(object):
                 continue
 
             print('Installing dependency: {}'.format('{}{}'.format(pkg_name, ver_spec if ver_spec else '')))
-            repository = get_repository(pkg_name)
+            repository = get_repository(pkg_name, verbose=self.verbose)
             try:
                 repository.install(pkg_name, ver_spec, dist=dependency_dist)
             except PackageAlreadyInstalled:

--- a/bin/pip.py
+++ b/bin/pip.py
@@ -1116,9 +1116,11 @@ class PyPIRepository(PackageRepository):
         """
         pkg_name = pkg_data['info']['name']
         if ver_spec is None:
+            # TODO: add compatibility check
             return self._package_latest_release(pkg_data)
         else:
             for hit in sorted(self._package_releases(pkg_data), reverse=True):
+                # TODO: more intiligent sort
                 # we return the fist matching hit, so we should sort the hits by descending version
                 if (dist is not None) and not self._dist_allows_release(dist, pkg_data, hit):
                     # hit has no source/binary release and is not allowed by dis
@@ -1145,24 +1147,19 @@ class PyPIRepository(PackageRepository):
         had_v = False
         has_source = False
         downloads = self._package_downloads(pkg_data, release)
-        print("checking: " + pkg_data["info"].get("name", "???"), "==", release)  # DEBUG
         for download in downloads:
             requires_python = download.get("requires_python", None)
             if requires_python is not None:
-                print("requires_python found: " + requires_python)  # DEBUG
                 reqs = "python" + requires_python
                 name, ver_spec = VersionSpecifier.parse_requirement(reqs)
                 assert name == "python"  # if this if False some large bug happened...
                 if all([op(platform.python_version(), ver) for op, ver in ver_spec.specs]):
                     # compatible
-                    print("COMPATIBLE!")  # DEBUG
                     return True
             else:
                 # fallback
-                print("falling back to python_version")  # DEBUG
                 # TODO: do we require this?
                 pv = download.get("python_version", None)
-                print("python_version: ", pv)  # DEBUG
                 if pv is None:
                     continue
                 elif pv in ("py2.py3", "py3.py2"):
@@ -1182,7 +1179,6 @@ class PyPIRepository(PackageRepository):
                     # however, this seems to be wrong. Instead, we use this as a fallback yes
                     has_source = True
             had_v = True
-        print("No compatible found! had_v: ", had_v, " has_source: ", has_source)  # DEBUG
         if had_v:
             # no allowed downloads found
             return has_source

--- a/bin/pip.py
+++ b/bin/pip.py
@@ -376,7 +376,13 @@ def sort_versions(versionlist):
             else:
                 # contains non-digits
                 i = s.start()
-                a, b = int(v[:i]), v[i:]
+                a, b = v[:i], v[i:]
+                if a == "":
+                    # sometimes, non-numeric versions are used for dev releases
+                    # we should fallback to 0, to give priority to non-dev versions
+                    a = 0
+                else:
+                    a = int(a)
             ret.append((a, b))
         return tuple(ret)
     return sorted(versionlist, key=sortf, reverse=True)

--- a/core.py
+++ b/core.py
@@ -5,7 +5,7 @@ StaSh - Pythonista Shell
 https://github.com/ywangd/stash
 """
 
-__version__ = '0.7.1'
+__version__ = '0.7.2'
 
 import imp as pyimp  # rename to avoid name conflict with objc_util
 import logging

--- a/lib/libversion.py
+++ b/lib/libversion.py
@@ -313,4 +313,11 @@ class VersionSpecifier(object):
         :return: whether the version is allowed or not
         :rtype: boolean
         """
-        return all([op(Version.parse(version), Version.parse(ver)) for op, ver in self.specs])
+        # return all([op(Version.parse(version), Version.parse(ver)) for op, ver in self.specs])
+        vi = Version.parse(version)
+        matches = True
+        for op, ver in self.specs:
+            evi = Version.parse(ver)
+            if not op(vi, evi):
+                matches = False
+        return matches

--- a/lib/libversion.py
+++ b/lib/libversion.py
@@ -117,7 +117,7 @@ def sort_versions(versionlist):
     :return: the sorted list
     :rtype: list of str
     """
-    return sorted(versionlist, sortkey=lambda s: Version.parse(s) if isinstance(s, str) else s, reverse=True)
+    return sorted(versionlist, key=lambda s: Version.parse(s) if isinstance(s, str) else s, reverse=True)
 
 
 class Version(object):
@@ -193,14 +193,37 @@ class Version(object):
         rpriority = self.RELEASE_TYPE_PRIORITIES.get(self.rtype, 0)
         return (self.epoch, self.versiontuple, rpriority, self.subversion, self.is_postrelease, self.postrelease, not self.is_devrelease, self.devrelease)
 
-    def __cmp__(self, other):
-        """
-        Compare to another object
-        """
-        if isinstance(other, self.__class__):
-            return cmp(self._get_sortkey(), other._get_sortkey())
+    def __eq__(self, other):
+        if isinstance(othjer, self.__class__):
+            return self._get_sortkey() == other._get_sortkey()
         else:
-            return 1  # assume greater than non-versions
+            return False
+
+    def __gt__(self, other):
+        if isinstance(othjer, self.__class__):
+            return self._get_sortkey() > other._get_sortkey()
+        else:
+            return True
+
+    def __lt__(self, other):
+        if isinstance(othjer, self.__class__):
+            return self._get_sortkey() < other._get_sortkey()
+        else:
+            return False
+
+    def __ge__(self, other):
+        if isinstance(othjer, self.__class__):
+            return self._get_sortkey() >= other._get_sortkey()
+        else:
+            return False
+
+    def __le__(self, other):
+        if isinstance(othjer, self.__class__):
+            return self._get_sortkey() <= other._get_sortkey()
+        else:
+            return False
+
+
 
     def __str__(self):
         """return a string representation of this version"""

--- a/lib/libversion.py
+++ b/lib/libversion.py
@@ -1,0 +1,102 @@
+"""version utilities"""
+import re
+import operator
+
+def sort_versions(versionlist):
+    """
+    Return a list containing the versions in versionlist, starting with the highest version.
+    :param versionlist: list of versions to sort
+    :type versionlist: list of str
+    :return: the sorted list
+    :rtype: list of str
+    """
+    def sortf(e):
+        """extract the key for the search"""
+        splitted = e.split(".")
+        ret = []
+        for v in splitted:
+            # some versions may contain a string
+            # in py3, comparsion between int and str is no longer possible :(
+            # thus we instead sort by a tuple of (int, str), where str is the non-digt part of the version
+            s = re.search("[^0-9]", v)
+            if s is None:
+                # only numbers
+                a, b = int(v), ""
+            else:
+                # contains non-digits
+                i = s.start()
+                a, b = v[:i], v[i:]
+                if a == "":
+                    # sometimes, non-numeric versions are used for dev releases
+                    # we should fallback to 0, to give priority to non-dev versions
+                    a = 0
+                else:
+                    a = int(a)
+            # ret.append((a, b))
+            ret.append(a)  # TODO: replace with above line. There still seem to be some issues with the order of versions containing non-digits.
+        return tuple(ret)
+    return sorted(versionlist, key=sortf, reverse=True)
+
+
+class VersionSpecifier(object):
+    """
+    This class is to represent the versions of a requirement, e.g. pyte==0.4.10.
+    """
+    OPS = {'<=': operator.le,
+    '<': operator.lt,
+    '!=': operator.ne,
+    '>=': operator.ge,
+    '>': operator.gt,
+    '==': operator.eq,
+    '~=': operator.ge}
+
+    def __init__(self, version_specs):
+        self.specs = [(VersionSpecifier.OPS[op], version) for (op, version) in version_specs]
+        self.str = str(version_specs)
+
+    def __str__(self):
+        return self.str
+
+    @staticmethod
+    def parse_requirement(requirement):
+        """
+        Factory method to create a VersionSpecifier object from a requirement
+        """
+        if isinstance(requirement, (list, tuple)):
+            if len(requirement) == 1:
+                requirement = requirement[0]
+            else:
+                raise ValueError("Unknown requirement format: " + repr(requirement))
+        # remove all whitespaces and '()'
+        requirement = requirement.replace(' ', '')
+        requirement = requirement.replace("(", "").replace(")", "")
+        if requirement.startswith("#"):
+            # ignore
+            return None, None
+        letterOrDigit = r'\w'
+        PAREN = lambda x: '(' + x + ')'
+
+        version_cmp = PAREN('?:' + '|'.join(('<=', '<', '!=', '>=', '>', '~=', '==')))
+        version_re = PAREN('?:' + '|'.join((letterOrDigit, '-', '_', '\.', '\*', '\+', '\!'))) + '+'
+        version_one = PAREN(version_cmp) + PAREN(version_re)
+        package_name = '^([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9._-]*[A-Za-z0-9])'
+        parsed = re.findall(package_name + version_one, requirement)
+
+        if not parsed:
+            return requirement, None
+        name = parsed[0][0]
+        reqt = list(zip(*parsed))
+        version_specifiers = list(zip(*reqt[1:]))  # ((op,version),(op,version))
+        version = VersionSpecifier(version_specifiers)
+
+        return name, version
+
+    def match(self, version):
+        """
+        Check if version is allowed by the version specifiers.
+        :param version: version to check
+        :type version: str
+        :return: whether the version is allowed or not
+        :rtype: boolean
+        """
+        return all([op(version, ver) for op, ver in self.specs])

--- a/lib/libversion.py
+++ b/lib/libversion.py
@@ -14,6 +14,101 @@ RELEASE_TYPE_PRIORITIES = {
 }
 
 
+def _parse_version(vs):
+    """
+    Parse a version string, e.g. '2!3.0.1.rc2.dev3'
+    :param vs: version to parse
+    :type vs: str
+    :return: a dict containing the fragments about the version
+    :rtype: dict
+    """
+    # NOTE: the below code may be a bit messy, because it was rewritten multiple times and then repurposed from a sort-function to a parsing-function
+    # version scheme (PEP440): [N!]N(.N)*[{a|b|rc}N][.postN][.devN]
+    # convert to lowercase, since all versions must be case insenstive (PEP440)
+    e = vs.lower()
+    # extract information from
+    if "!" in e:
+        # read epoch
+        es = e[:e.find("!")]
+        e = e[e.find("!") + 1:]
+        epoch = int(es)
+    else:
+        # default epoch is 0
+        epoch = 0
+    # parse version tuple
+    veis = re.search("[^0-9\\.]", e)
+    if veis is None:
+        # no non-digits
+        vei = len(e)
+    else:
+        vei = veis.start()
+    vstr = e[:vei]
+    while vstr.endswith("."):
+        # remove trailing '.'
+        vstr = vstr[:-1]
+    splitted = vstr.split(".")
+    verparts = []
+    for v in splitted:
+        verparts.append(int(v))
+    # parse post release
+    rtstr = e[vei:]
+    if "post" in rtstr:
+        postrnstr = rtstr[rtstr.find("post") + 4:]
+        postrnres = re.search("[0-9]*", postrnstr)
+        if postrnres is None or postrnres.end() == 0:
+            # PEP440: implicit post version 0
+            subpriority = 0
+        else:
+            subpriority = int(postrnstr[:postrnres.end()])
+        rtstr = rtstr[:rtstr.find("post") - 1]
+        is_post = True
+    else:
+        subpriority = 0
+        is_post = False
+    # parse release type
+    rtype = None
+    if len(rtstr) == 0:
+        rtype = None
+    elif rtstr[0] in ("a", "b"):
+        rtype = rtstr[0]
+    elif rtstr.startswith("rc"):
+        rtype = "rc"
+    # parse number of release
+    if rtype is None:
+        # not needed
+        rsubpriority = 0
+    else:
+        # 1. strip rtype
+        rtps = rtstr[len(rtype):]
+        # 2. extract until non-digit
+        rtpsr = re.search("[0-9]*", rtps)
+        if rtpsr is None or rtpsr.end() == 0:
+            # no number
+            rsubpriority = 0
+        else:
+            rsubpriority = int(rtps[:rtpsr.end()])
+    # extract dev release information
+    devr = re.search("\\.?dev[0-9]*", e)
+    if devr is None:
+        isdev = False
+        devnum = 0
+    else:
+        isdev = True
+        devns = e[devr.start() + 4:]  # 4: 1 for '.'; 3 for 'dev'
+        if len(devns) == 0:
+            devnum = 0
+        else:
+            devnum = int(devns)
+    return {
+        "epoch": epoch,
+        "versiontuple": tuple(verparts),
+        "rtype": rtype,
+        "subversion": rsubpriority,
+        "postrelease": (subpriority if is_post else None),
+        "devrelease": (devnum if isdev else None),
+        }
+
+
 def sort_versions(versionlist):
     """
     Return a list containing the versions in versionlist, starting with the highest version.
@@ -22,94 +117,114 @@ def sort_versions(versionlist):
     :return: the sorted list
     :rtype: list of str
     """
-    # version scheme (PEP440): [N!]N(.N)*[{a|b|rc}N][.postN][.devN]
-    # order:
-    # 1. epoch
-    # 2. release version
-    # 3. postrelease > release > prerelease
-    # 4. postrelease#
-    # 5. non-dev > dev
-    # 6. dev#
-    def sortf(e):
-        """extract the key for the search"""
-        # convert to lowercase, since all versions must be case insenstive (PEP440)
-        e = e.lower()
-        # extract information from
-        if "!" in e:
-            # read epoch
-            es = e[:e.find("!")]
-            e = e[e.find("!") + 1:]
-            epoch = int(es)
+    return sorted(versionlist, sortkey=lambda s: Version.parse(s) if isinstance(s, str) else s, reverse=True)
+
+
+class Version(object):
+    """
+    This class represents a version. It is mainly used for version comparsion.
+    """
+    TYPE_NORMAL = None
+    TYPE_ALPHA = "a"
+    TYPE_BETA = "b"
+    TYPE_RELEASE_CANDIDATE = "rc"
+
+    RELEASE_TYPE_PRIORITIES = {
+        # priority of a release type. greate => higher priority
+        TYPE_NORMAL: 3,   # no release type
+        TYPE_ALPHA: 0,    # alpha post release
+        TYPE_BETA: 1,    # beta post release
+        TYPE_RELEASE_CANDIDATE: 2,   # release candidate
+    }
+
+    def __init__(self, epoch=0, versiontuple=(), rtype=None, subversion=0, postrelease=None, devrelease=None):
+        assert isinstance(epoch, int)
+        assert isinstance(versiontuple, tuple)
+        assert isinstance(rtype, str) or rtype is None
+        assert isinstance(subversion, int)
+        assert isinstance(postrelease, int) or postrelease is None
+        assert isinstance(devrelease, int) or devrelease is None
+        self.epoch = epoch
+        self.versiontuple = versiontuple
+        self.rtype = rtype
+        self.subversion = subversion
+        self.postrelease = postrelease
+        self.devrelease = devrelease
+
+    @classmethod
+    def parse(cls, s):
+        """
+        Parse a versionstring and return a Version() of it.
+        :param s: string to parse
+        :type s: str
+        :return: a Version() instance describing the parsed string
+        :rtype: Version
+        """
+        if isinstance(s, cls):
+            # s is already a Version
+            return s
+        parsed = _parse_version(s)
+        return Version(**parsed)
+
+    @property
+    def is_postrelease(self):
+        """whether this version is a postrelease or not"""
+        return self.postrelease is not None
+
+    @property
+    def is_devrelease(self):
+        """whether this version is a devrelease or not"""
+        return self.devrelease is not None
+
+    def _get_sortkey(self):
+        """
+        Return a value which can be used to compare two versions.
+        Sort order:
+        1. epoch
+        2. release version
+        3. postrelease > release > prerelease
+        4. postrelease#
+        5. non-dev > dev
+        6. dev#
+
+        :return: a value which can be used for comparing this version to another version
+        :rtype: tuple
+        """
+        rpriority = self.RELEASE_TYPE_PRIORITIES.get(self.rtype, 0)
+        return (self.epoch, self.versiontuple, rpriority, self.subversion, self.is_postrelease, self.postrelease, not self.is_devrelease, self.devrelease)
+
+    def __cmp__(self, other):
+        """
+        Compare to another object
+        """
+        if isinstance(other, self.__class__):
+            return cmp(self._get_sortkey(), other._get_sortkey())
         else:
-            # default epoch is 0
-            epoch = 0
-        # parse version tuple
-        veis = re.search("[^0-9\\.]", e)
-        if veis is None:
-            # no non-digits
-            vei = len(e)
-        else:
-            vei = veis.start()
-        vstr = e[:vei]
-        while vstr.endswith("."):
-            # remove trailing '.'
-            vstr = vstr[:-1]
-        splitted = vstr.split(".")
-        verparts = []
-        for v in splitted:
-            verparts.append(int(v))
-        # parse post release
-        rtstr = e[vei:]
-        if "post" in rtstr:
-            try:
-                subpriority = int(rtstr[rtstr.find("post") + 4:])
-            except ValueError:
-                # PEP440: implicit post version 0
-                subpriority = 0
-            rtstr = rtstr[:rtstr.find("post") - 1]
-            is_post = True
-        else:
-            subpriority = 0
-            is_post = False
-        # parse release type
-        rtype = None
-        if len(rtstr) == 0:
-            rtype = None
-        elif rtstr[0] in ("a", "b"):
-            rtype = rtstr[0]
-        elif rtstr.startswith("rc"):
-            rtype = "rc"
-        # parse number of release
-        if rtype is None:
-            # not needed
-            rsubpriority = 0
-        else:
-            # 1. strip rtype
-            rtps = rtstr[len(rtype):]
-            # 2. extract until non-digit
-            rtpsr = re.search("[0-9]*", rtps)
-            if rtpsr is None or rtpsr.end() == 0:
-                # no number
-                rsubpriority = 0
-            else:
-                rsubpriority = int(rtps[:rtpsr.end()])
-        rpriority = RELEASE_TYPE_PRIORITIES.get(rtype, 0)  # unknown -> be skeptical
-        # extract dev release information
-        devr = re.search("\\.?dev[0-9]*", rtstr)
-        if devr is None:
-            isdev = False
-            devnum = 0
-        else:
-            isdev = True
-            devns = rtstr[devr.start() + 4:]  # 4: 1 for '.'; 3 for 'dev'
-            if len(devns) == 0:
-                devnum = 0
-            else:
-                devnum = int(devns)
-        # below is the search key (=value by which the version list will be ordered)
-        # comparsion *should* be from i=0 to i=-1
-        return (epoch, tuple(verparts), rpriority, rsubpriority, is_post, subpriority, not isdev, devnum)
-    return sorted(versionlist, key=sortf, reverse=True)
+            return 1  # assume greater than non-versions
+
+    def __str__(self):
+        """return a string representation of this version"""
+        version = ".".join([str(e) for e in self.versiontuple])  # base version
+        # epoch
+        if self.epoch > 0:
+            version = str(self.epoch) + "!" + version
+        # release type
+        if self.rtype is not None:
+            version += "." + self.rtype
+            if self.subversion > 0:
+                version += str(self.subversion)
+        # postrelease
+        if self.is_postrelease:
+            version += ".post"
+            if self.postrelease > 0:
+                version += str(self.postrelease)
+        # devrelease
+        if self.is_devrelease:
+            version += ".dev"
+            if self.devrelease > 0:
+                version += str(self.devrelease)
+        # done
+        return version
 
 
 class VersionSpecifier(object):
@@ -175,4 +290,4 @@ class VersionSpecifier(object):
         :return: whether the version is allowed or not
         :rtype: boolean
         """
-        return all([op(version, ver) for op, ver in self.specs])
+        return all([op(Version.parse(version), Version.parse(ver)) for op, ver in self.specs])

--- a/lib/libversion.py
+++ b/lib/libversion.py
@@ -314,10 +314,17 @@ class VersionSpecifier(object):
         :rtype: boolean
         """
         # return all([op(Version.parse(version), Version.parse(ver)) for op, ver in self.specs])
-        vi = Version.parse(version)
         matches = True
         for op, ver in self.specs:
-            evi = Version.parse(ver)
-            if not op(vi, evi):
-                matches = False
+            try:
+                vi = Version.parse(version)
+                evi = Version.parse(ver)
+            except:
+                # warning: wildcard except!
+                # fallback to old, string-based comparsion
+                if not op(version, ver):
+                    matches = False
+            else:
+                if not op(vi, evi):
+                    matches = False
         return matches

--- a/lib/libversion.py
+++ b/lib/libversion.py
@@ -97,14 +97,15 @@ def sort_versions(versionlist):
         # extract dev release information
         devr = re.search("\\.?dev[0-9]*", rtstr)
         if devr is None:
+            isdev = False
             devnum = 0
         else:
+            isdev = True
             devns = rtstr[devr.start() + 4:]  # 4: 1 for '.'; 3 for 'dev'
             if len(devns) == 0:
                 devnum = 0
             else:
                 devnum = int(devns)
-        isdev = (devnum != None)
         # below is the search key (=value by which the version list will be ordered)
         # comparsion *should* be from i=0 to i=-1
         return (epoch, tuple(verparts), rpriority, rsubpriority, is_post, subpriority, not isdev, devnum)

--- a/lib/libversion.py
+++ b/lib/libversion.py
@@ -287,22 +287,20 @@ class VersionSpecifier(object):
         if requirement.startswith("#"):
             # ignore
             return None, None
-        letterOrDigit = r'\w'
         PAREN = lambda x: '(' + x + ')'
-
         version_cmp = PAREN('?:' + '|'.join(('<=', '<', '!=', '>=', '>', '~=', '==')))
-        version_re = PAREN('?:' + '|'.join((letterOrDigit, '-', '_', '\.', '\*', '\+', '\!'))) + '+'
-        version_one = PAREN(version_cmp) + PAREN(version_re)
-        package_name = '^([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9._-]*[A-Za-z0-9])'
-        parsed = re.findall(package_name + version_one, requirement)
-
-        if not parsed:
+        name_end_res = re.search(version_cmp, requirement)
+        if name_end_res is None:
             return requirement, None
-        name = parsed[0][0]
-        reqt = list(zip(*parsed))
-        version_specifiers = list(zip(*reqt[1:]))  # ((op,version),(op,version))
-        version = VersionSpecifier(version_specifiers)
-
+        name_end = name_end_res.start()
+        name, specs_s = requirement[:name_end], requirement[name_end:]
+        splitted = specs_s.split(",")
+        specs = []
+        for vs in splitted:
+            cmp_end = re.search(version_cmp, vs).end()
+            c, v = vs[:cmp_end], vs[cmp_end:]
+            specs.append((c, v))
+        version = VersionSpecifier(specs)
         return name, version
 
     def match(self, version):

--- a/lib/libversion.py
+++ b/lib/libversion.py
@@ -194,31 +194,31 @@ class Version(object):
         return (self.epoch, self.versiontuple, rpriority, self.subversion, self.is_postrelease, self.postrelease, not self.is_devrelease, self.devrelease)
 
     def __eq__(self, other):
-        if isinstance(othjer, self.__class__):
+        if isinstance(other, self.__class__):
             return self._get_sortkey() == other._get_sortkey()
         else:
             return False
 
     def __gt__(self, other):
-        if isinstance(othjer, self.__class__):
+        if isinstance(other, self.__class__):
             return self._get_sortkey() > other._get_sortkey()
         else:
             return True
 
     def __lt__(self, other):
-        if isinstance(othjer, self.__class__):
+        if isinstance(other, self.__class__):
             return self._get_sortkey() < other._get_sortkey()
         else:
             return False
 
     def __ge__(self, other):
-        if isinstance(othjer, self.__class__):
+        if isinstance(other, self.__class__):
             return self._get_sortkey() >= other._get_sortkey()
         else:
             return False
 
     def __le__(self, other):
-        if isinstance(othjer, self.__class__):
+        if isinstance(other, self.__class__):
             return self._get_sortkey() <= other._get_sortkey()
         else:
             return False

--- a/lib/stashutils/wheels.py
+++ b/lib/stashutils/wheels.py
@@ -296,6 +296,7 @@ class DependencyHandler(BaseHandler):
         dependencies = []
         with open(p, "r") as fin:
             for line in fin:
+                line = line.replace("\n", "")
                 if line.startswith("Requires-Dist: "):
                     t = line[len("Requires-Dist: "):]
                     if ";" in t:

--- a/lib/stashutils/wheels.py
+++ b/lib/stashutils/wheels.py
@@ -291,7 +291,6 @@ class DependencyHandler(BaseHandler):
         else:
             with open(metajsonp, "r") as fin:
                 content = json.load(fin)
-            # dependencies = content.get("run_requires", [{"requires": []}])[0]["requires"]
             dependencies = []
             for ds in content.get("run_requires", []):
                 ex = ds.get("extra", None)
@@ -301,7 +300,7 @@ class DependencyHandler(BaseHandler):
                         # extra not wanted
                         continue
                 else:
-                    dependencies.append(dep)
+                    dependencies += dep
         self.wheel.dependencies += dependencies
 
     def read_dependencies_from_METADATA(self, p):

--- a/lib/stashutils/wheels.py
+++ b/lib/stashutils/wheels.py
@@ -9,346 +9,378 @@ import zipfile
 import six
 from six.moves import configparser
 
-from stashutils.extensions import create_command
+try:
+    from stashutils.extensions import create_command
+except ImportError:
+    create_command = None
 
 
 class WheelError(Exception):
-	"""Error related to a wheel."""
-	pass
+    """Error related to a wheel."""
+    pass
 
 
 def parse_wheel_name(filename):
-	"""
-	Parse the filename of a wheel and return the information as dict.
-	"""
-	if not filename.endswith(".whl"):
-		raise WheelError("PEP427 violation: wheels need to end with '.whl'")
-	else:
-		filename = filename[:-4]
-	splitted = filename.split("-")
-	distribution = splitted[0]
-	version = splitted[1]
-	if len(splitted) == 6:
-		build_tag = splitted[2]
-		python_tag = splitted[3]
-		abi_tag = splitted[4]
-		platform_tag = splitted[5]
-	elif len(splitted) == 5:
-		build_tag = None
-		python_tag = splitted[2]
-		abi_tag = splitted[3]
-		platform_tag = splitted[4]
-	else:
-		raise WheelError("PEP427 violation: invalid naming schema")
-	return {
-		"distribution": distribution,
-		"version": version,
-		"build_tag": build_tag,
-		"python_tag": python_tag,
-		"abi_tag": abi_tag,
-		"platform_tag": platform_tag,
-	}
+    """
+    Parse the filename of a wheel and return the information as dict.
+    """
+    if not filename.endswith(".whl"):
+        raise WheelError("PEP427 violation: wheels need to end with '.whl'")
+    else:
+        filename = filename[:-4]
+    splitted = filename.split("-")
+    distribution = splitted[0]
+    version = splitted[1]
+    if len(splitted) == 6:
+        build_tag = splitted[2]
+        python_tag = splitted[3]
+        abi_tag = splitted[4]
+        platform_tag = splitted[5]
+    elif len(splitted) == 5:
+        build_tag = None
+        python_tag = splitted[2]
+        abi_tag = splitted[3]
+        platform_tag = splitted[4]
+    else:
+        raise WheelError("PEP427 violation: invalid naming schema")
+    return {
+        "distribution": distribution,
+        "version": version,
+        "build_tag": build_tag,
+        "python_tag": python_tag,
+        "abi_tag": abi_tag,
+        "platform_tag": platform_tag,
+    }
 
 
 def escape_filename_component(fragment):
-	"""
-	Escape a component of the filename as specified in PEP 427.
-	"""
-	return re.sub("[^\w\d.]+", "_", fragment, re.UNICODE)
+    """
+    Escape a component of the filename as specified in PEP 427.
+    """
+    return re.sub("[^\w\d.]+", "_", fragment, re.UNICODE)
 
 
 def generate_filename(
-	distribution,
-	version,
-	build_tag=None,
-	python_tag=None,
-	abi_tag=None,
-	platform_tag=None,
-	):
-	"""
-	Generate a filename for the wheel and return it.
-	"""
-	if python_tag is None:
-		if six.PY3:
-			python_tag = "py3"
-		else:
-			python_tag = "py2"
-	if abi_tag is None:
-		abi_tag = "none"
-	if platform_tag is None:
-		platform_tag = "any"
-	return "{d}-{v}{b}-{py}-{a}-{p}.whl".format(
-		d=escape_filename_component(distribution),
-		v=escape_filename_component(version),
-		b=("-" + escape_filename_component(build_tag) if build_tag is not None else ""),
-		py=escape_filename_component(python_tag),
-		a=escape_filename_component(abi_tag),
-		p=escape_filename_component(platform_tag),
-		)
+    distribution,
+    version,
+    build_tag=None,
+    python_tag=None,
+    abi_tag=None,
+    platform_tag=None,
+    ):
+    """
+    Generate a filename for the wheel and return it.
+    """
+    if python_tag is None:
+        if six.PY3:
+            python_tag = "py3"
+        else:
+            python_tag = "py2"
+    if abi_tag is None:
+        abi_tag = "none"
+    if platform_tag is None:
+        platform_tag = "any"
+    return "{d}-{v}{b}-{py}-{a}-{p}.whl".format(
+        d=escape_filename_component(distribution),
+        v=escape_filename_component(version),
+        b=("-" + escape_filename_component(build_tag) if build_tag is not None else ""),
+        py=escape_filename_component(python_tag),
+        a=escape_filename_component(abi_tag),
+        p=escape_filename_component(platform_tag),
+        )
 
 
 def wheel_is_compatible(filename):
-	"""
-	Return True if the wheel is compatible, False otherwise.
-	"""
-	data = parse_wheel_name(filename)
-	if ("py2.py3" in data["python_tag"]) or ("py3.py2" in data["python_tag"]):
-		# only here to skip elif/else
-		pass
-	elif six.PY3:
-		if not data["python_tag"].startswith("py3"):
-			return False
-	else:
-		if not data["python_tag"].startswith("py2"):
-			return False
-	if data["abi_tag"].lower() != "none":
-		return False
-	if data["platform_tag"].lower() != "any":
-		return False
-	return True
+    """
+    Return True if the wheel is compatible, False otherwise.
+    """
+    data = parse_wheel_name(filename)
+    if ("py2.py3" in data["python_tag"]) or ("py3.py2" in data["python_tag"]):
+        # only here to skip elif/else
+        pass
+    elif six.PY3:
+        if not data["python_tag"].startswith("py3"):
+            return False
+    else:
+        if not data["python_tag"].startswith("py2"):
+            return False
+    if data["abi_tag"].lower() != "none":
+        return False
+    if data["platform_tag"].lower() != "any":
+        return False
+    return True
 
 
 class BaseHandler(object):
-	"""
-	Baseclass for installation handlers.
-	"""
-	name = "<name not set>"
-	
-	def __init__(self, wheel, verbose=False):
-		self.wheel = wheel
-		self.verbose = verbose
-	
-	def copytree(self, packagepath, src, dest, remove=False):
-		"""
-		Copies a package directory tree.
-		:param packagepath: relative path of the (sub-)package, e.g. 'package/subpackage/'
-		:type packagepath: str
-		:param src: path to the actual source of the root package
-		:type src: str
-		:param dest: path to copy to
-		:type dest: str
-		:return: the path to which the directories have been copied.
-		:trype: str
-		"""
-		if self.verbose:
-			print("Copying {s} -> {d}".format(s=src, d=dest))
-		if os.path.isfile(src):
-			if os.path.isdir(dest):
-				dest = os.path.join(dest, os.path.basename(src))
-			if os.path.exists(dest) and remove:
-				os.remove(dest)
-			shutil.copy(src, dest)
-			return dest
-		else:
-			target = os.path.join(
-				dest,
-				# os.path.basename(os.path.normpath(src)),
-				packagepath,
-				)
-			if os.path.exists(target) and remove:
-				shutil.rmtree(target)
-			shutil.copytree(src, target)
-			return target
-	
-	@property
-	def distinfo_name(self):
-		"""the name of the *.dist-info directory."""
-		data = parse_wheel_name(self.wheel.filename)
-		return "{pkg}-{v}.dist-info".format(
-			pkg=data["distribution"],
-			v=data["version"],
-			)
+    """
+    Baseclass for installation handlers.
+    """
+    name = "<name not set>"
+
+    def __init__(self, wheel, verbose=False):
+        self.wheel = wheel
+        self.verbose = verbose
+
+    def copytree(self, packagepath, src, dest, remove=False):
+        """
+        Copies a package directory tree.
+        :param packagepath: relative path of the (sub-)package, e.g. 'package/subpackage/'
+        :type packagepath: str
+        :param src: path to the actual source of the root package
+        :type src: str
+        :param dest: path to copy to
+        :type dest: str
+        :return: the path to which the directories have been copied.
+        :trype: str
+        """
+        if self.verbose:
+            print("Copying {s} -> {d}".format(s=src, d=dest))
+        if os.path.isfile(src):
+            if os.path.isdir(dest):
+                dest = os.path.join(dest, os.path.basename(src))
+            if os.path.exists(dest) and remove:
+                os.remove(dest)
+            shutil.copy(src, dest)
+            return dest
+        else:
+            target = os.path.join(
+                dest,
+                # os.path.basename(os.path.normpath(src)),
+                packagepath,
+                )
+            if os.path.exists(target) and remove:
+                shutil.rmtree(target)
+            shutil.copytree(src, target)
+            return target
+
+    @property
+    def distinfo_name(self):
+        """the name of the *.dist-info directory."""
+        data = parse_wheel_name(self.wheel.filename)
+        return "{pkg}-{v}.dist-info".format(
+            pkg=data["distribution"],
+            v=data["version"],
+            )
 
 
 class TopLevelHandler(BaseHandler):
-	"""Handler for 'top_level.txt'"""
-	name = "top_level.txt installer"
-	
-	def handle_install(self, src, dest):
-		tltxtp = os.path.join(src, self.distinfo_name, "top_level.txt")
-		files_installed = []
-		with open(tltxtp, "r") as fin:
-			for pkg_name in fin:
-				pure = pkg_name.replace("\r", "").replace("\n", "")
-				sp = os.path.join(src, pure)
-				if os.path.exists(sp):
-					p = self.copytree(pure, sp, dest, remove=True)
-				elif os.path.exists(sp + ".py"):
-					dp = os.path.join(dest, pure + ".py")
-					p = self.copytree(pure, sp + ".py", dp, remove=True)
-				else:
-					raise WheelError("top_level.txt entry '{e}' not found in toplevel directory!".format(e=pure))
-				files_installed.append(p)
-		return files_installed
+    """Handler for 'top_level.txt'"""
+    name = "top_level.txt installer"
+
+    def handle_install(self, src, dest):
+        tltxtp = os.path.join(src, self.distinfo_name, "top_level.txt")
+        files_installed = []
+        with open(tltxtp, "r") as fin:
+            for pkg_name in fin:
+                pure = pkg_name.replace("\r", "").replace("\n", "")
+                sp = os.path.join(src, pure)
+                if os.path.exists(sp):
+                    p = self.copytree(pure, sp, dest, remove=True)
+                elif os.path.exists(sp + ".py"):
+                    dp = os.path.join(dest, pure + ".py")
+                    p = self.copytree(pure, sp + ".py", dp, remove=True)
+                else:
+                    raise WheelError("top_level.txt entry '{e}' not found in toplevel directory!".format(e=pure))
+                files_installed.append(p)
+        return files_installed
 
 
 class ConsoleScriptsHandler(BaseHandler):
-	"""Handler for 'console_scripts'."""
-	name = "console_scripts installer"
-	
-	def handle_install(self, src, dest):
-		eptxtp = os.path.join(src, self.distinfo_name, "entry_points.txt")
-		if not os.path.exists(eptxtp):
-			if self.verbose:
-				print("No entry_points.txt found, skipping.")
-			return
-		parser = configparser.ConfigParser()
-		try:
-			parser.read(eptxtp)
-		except configparser.MissingSectionHeaderError:
-			# print message and return
-			if self.verbose:
-				print("No section headers found in entry_points.txt, passing.")
-				return
-		if not parser.has_section("console_scripts"):
-			if self.verbose:
-				print("No console_scripts definition found, skipping.")
-			return
-		
-		files_installed = []
-		
-		mdp = os.path.join(src, self.distinfo_name, "metadata.json")
-		if os.path.exists(mdp):
-			with open(mdp, "r") as fin:
-				desc = json.load(fin).get("summary", "???")
-		else:
-			desc = "???"
-		
-		for command, definition in parser.items(section="console_scripts"):
-			# name, loc = definition.replace(" ", "").split("=")
-			modname, funcname = definition.split(":")
-			if not command.endswith(".py"):
-				command += ".py"
-			path = create_command(
-				command,
-				(u"""'''%s'''
+    """Handler for 'console_scripts'."""
+    name = "console_scripts installer"
+
+    def handle_install(self, src, dest):
+        eptxtp = os.path.join(src, self.distinfo_name, "entry_points.txt")
+        if not os.path.exists(eptxtp):
+            if self.verbose:
+                print("No entry_points.txt found, skipping.")
+            return
+        parser = configparser.ConfigParser()
+        try:
+            parser.read(eptxtp)
+        except configparser.MissingSectionHeaderError:
+            # print message and return
+            if self.verbose:
+                print("No section headers found in entry_points.txt, passing.")
+                return
+        if not parser.has_section("console_scripts"):
+            if self.verbose:
+                print("No console_scripts definition found, skipping.")
+            return
+
+        if create_command is None:
+            if self.verbose:
+                print("Warning: could not import create_command(); skipping.")
+            return
+
+        files_installed = []
+
+        mdp = os.path.join(src, self.distinfo_name, "metadata.json")
+        if os.path.exists(mdp):
+            with open(mdp, "r") as fin:
+                desc = json.load(fin).get("summary", "???")
+        else:
+            desc = "???"
+
+        for command, definition in parser.items(section="console_scripts"):
+            # name, loc = definition.replace(" ", "").split("=")
+            modname, funcname = definition.split(":")
+            if not command.endswith(".py"):
+                command += ".py"
+            path = create_command(
+                command,
+                (u"""'''%s'''
 from %s import %s
 
 if __name__ == "__main__":
     %s()
 """ % (desc, modname, funcname, funcname)).encode("utf-8"))
-			files_installed.append(path)
-		return files_installed
+            files_installed.append(path)
+        return files_installed
 
 
 class WheelInfoHandler(BaseHandler):
-	"""Handler for wheel informations."""
-	name = "WHEEL information checker"
-	supported_major_versions = [1]
-	supported_versions = ["1.0"]
-	
-	def handle_install(self, src, dest):
-		wtxtp = os.path.join(src, self.distinfo_name, "WHEEL")
-		with open(wtxtp, "r") as fin:
-			for line in fin:
-				line = line.replace("\r", "").replace("\n", "")
-				ki = line.find(":")
-				key = line[:ki]
-				value = line[ki+2:]
-				
-				if key.lower() == "wheel-version":
-					major, minor = value.split(".")
-					major, minor = int(major), int(minor)
-					if major not in self.supported_major_versions:
-						raise WheelError("Wheel major version is incompatible!")
-					if value not in self.supported_versions:
-						print("WARNING: unsupported minor version: " + str(value))
-					self.wheel.version = (major, minor)
-				
-				elif key.lower() == "generator":
-					if self.verbose:
-						print("Wheel generated by: " + value)
-		return []
+    """Handler for wheel informations."""
+    name = "WHEEL information checker"
+    supported_major_versions = [1]
+    supported_versions = ["1.0"]
+
+    def handle_install(self, src, dest):
+        wtxtp = os.path.join(src, self.distinfo_name, "WHEEL")
+        with open(wtxtp, "r") as fin:
+            for line in fin:
+                line = line.replace("\r", "").replace("\n", "")
+                ki = line.find(":")
+                key = line[:ki]
+                value = line[ki+2:]
+
+                if key.lower() == "wheel-version":
+                    major, minor = value.split(".")
+                    major, minor = int(major), int(minor)
+                    if major not in self.supported_major_versions:
+                        raise WheelError("Wheel major version is incompatible!")
+                    if value not in self.supported_versions:
+                        print("WARNING: unsupported minor version: " + str(value))
+                    self.wheel.version = (major, minor)
+
+                elif key.lower() == "generator":
+                    if self.verbose:
+                        print("Wheel generated by: " + value)
+        return []
 
 
 class DependencyHandler(BaseHandler):
-	"""
-	Handler for the dependencies.
-	"""
-	name = "dependency handler"
-	
-	def handle_install(self, src, dest):
-		metap = os.path.join(src, self.distinfo_name, "metadata.json")
-		if not os.path.exists(metap):
-			if self.verbose:
-				print("Warning: could not find 'metadata.json', can not detect dependencies!")
-			return
-		with open(metap, "r") as fin:
-			content = json.load(fin)
-		dependencies = content.get("run_requires", [{"requires": []}])[0]["requires"]
-		self.wheel.dependencies += dependencies
-	
-		
+    """
+    Handler for the dependencies.
+    """
+    name = "dependency handler"
+
+    def handle_install(self, src, dest):
+        metajsonp = os.path.join(src, self.distinfo_name, "metadata.json")
+        metadatap = os.path.join(src, self.distinfo_name, "METADATA")
+        if not os.path.exists(metajsonp):
+            if os.path.exists(metadatap):
+                dependencies = self.read_dependencies_from_METADATA(metadatap)
+            else:
+                if self.verbose:
+                    print("Warning: could find neither 'metadata.json' not `METADATA`, can not detect dependencies!")
+                return
+        else:
+            with open(metajsonp, "r") as fin:
+                content = json.load(fin)
+            dependencies = content.get("run_requires", [{"requires": []}])[0]["requires"]
+        self.wheel.dependencies += dependencies
+
+    def read_dependencies_from_METADATA(self, p):
+        """read dependencies from distinfo/METADATA"""
+        dependencies = []
+        with open(p, "r") as fin:
+            for line in fin:
+                if line.startswith("Requires-Dist: "):
+                    t = line[len("Requires-Dist: "):]
+                    if ";" in t:
+                        # TODO: handle extras
+                        es = t[t.find(";") + 1]
+                        t = t[:t.find(";")]
+                    if "(" in t:
+                        # TODO: handle versions
+                        t = t[:t.find("(")]
+                        while t.endswith(" "):
+                            t = t[:-1]
+                    dependencies.append(t)
+        return dependencies
+
+
 # list of default handlers
 DEFAULT_HANDLERS = [
-	WheelInfoHandler,
-	DependencyHandler,
-	TopLevelHandler,
-	ConsoleScriptsHandler,
-	]
+    WheelInfoHandler,
+    DependencyHandler,
+    TopLevelHandler,
+    ConsoleScriptsHandler,
+    ]
 
 
 class Wheel(object):
-	"""class for installing python wheels."""
-	def __init__(self, path, handlers=DEFAULT_HANDLERS, verbose=False):
-		self.path = path
-		self.verbose = True
-		self.filename = os.path.basename(self.path)
-		self.handlers = [handler(self, self.verbose) for handler in handlers]
-		self.version = None  # to be set by handler
-		self.dependencies = []  # to be set by handler
-		
-		if not wheel_is_compatible(self.filename):
-			raise WheelError("Incompatible wheel: {p}!".format(p=self.filename))
-		
-	def install(self, targetdir):
-		"""
-		Install the wheel into the target directory.
-		Return (files_installed, dependencies)
-		"""
-		if self.verbose:
-			print("Extracting wheel..")
-		tp = self.extract_into_temppath()
-		if self.verbose:
-			print("Extraction finished, running handlers...")
-		try:
-			files_installed = []
-			for handler in self.handlers:
-				if hasattr(handler, "handle_install"):
-					if self.verbose:
-						print("Running handler '{h}'...".format(
-							h=getattr(handler, "name", "<unknown>"))
-							)
-					tfi = handler.handle_install(tp, targetdir)
-					if tfi is not None:
-						files_installed += tfi
-		finally:
-			if self.verbose:
-				print("Cleaning up...")
-			if os.path.exists(tp):
-				shutil.rmtree(tp)
-		return (files_installed, self.dependencies)
-	
-	def extract_into_temppath(self):
-		"""
-		Extract the wheel into a temporary directory.
-		Return the path of the temporary directory.
-		"""
-		p = os.path.join(tempfile.gettempdir(), "wheel_tmp", self.filename)
-		if not os.path.exists(p):
-			os.makedirs(p)
-		
-		with zipfile.ZipFile(self.path, mode="r") as zf:
-			zf.extractall(p)
-		
-		return p
+    """class for installing python wheels."""
+    def __init__(self, path, handlers=DEFAULT_HANDLERS, verbose=False):
+        self.path = path
+        self.verbose = True
+        self.filename = os.path.basename(self.path)
+        self.handlers = [handler(self, self.verbose) for handler in handlers]
+        self.version = None  # to be set by handler
+        self.dependencies = []  # to be set by handler
+
+        if not wheel_is_compatible(self.filename):
+            raise WheelError("Incompatible wheel: {p}!".format(p=self.filename))
+
+    def install(self, targetdir):
+        """
+        Install the wheel into the target directory.
+        Return (files_installed, dependencies)
+        """
+        if self.verbose:
+            print("Extracting wheel..")
+        tp = self.extract_into_temppath()
+        if self.verbose:
+            print("Extraction finished, running handlers...")
+        try:
+            files_installed = []
+            for handler in self.handlers:
+                if hasattr(handler, "handle_install"):
+                    if self.verbose:
+                        print("Running handler '{h}'...".format(
+                            h=getattr(handler, "name", "<unknown>"))
+                            )
+                    tfi = handler.handle_install(tp, targetdir)
+                    if tfi is not None:
+                        files_installed += tfi
+        finally:
+            if self.verbose:
+                print("Cleaning up...")
+            if os.path.exists(tp):
+                shutil.rmtree(tp)
+        return (files_installed, self.dependencies)
+
+    def extract_into_temppath(self):
+        """
+        Extract the wheel into a temporary directory.
+        Return the path of the temporary directory.
+        """
+        p = os.path.join(tempfile.gettempdir(), "wheel_tmp", self.filename)
+        if not os.path.exists(p):
+            os.makedirs(p)
+
+        with zipfile.ZipFile(self.path, mode="r") as zf:
+            zf.extractall(p)
+
+        return p
 
 
 if __name__ == "__main__":
-	# test script
-	import sys
-	fi, dep = Wheel(sys.argv[1], verbose=True).install(os.path.expanduser("~/Documents/site-packages/"))
-	print("files installed: ")
-	print(fi)
-	print("dependencies:")
-	print(dep)
+    # test script
+    import sys
+    fi, dep = Wheel(sys.argv[1], verbose=True).install(os.path.expanduser("~/Documents/site-packages/"))
+    print("files installed: ")
+    print(fi)
+    print("dependencies:")
+    print(dep)

--- a/lib/stashutils/wheels.py
+++ b/lib/stashutils/wheels.py
@@ -318,7 +318,7 @@ class DependencyHandler(BaseHandler):
                                 continue
                         elif rq == "extra":
                             # handle extra dependencies
-                            if not v.match(self.wheel.extra):
+                            if (self.wheel.extra is None) or (not v.match(self.wheel.extra)):
                                 # dependency NOT required
                                 continue
                         else:

--- a/lib/stashutils/wheels.py
+++ b/lib/stashutils/wheels.py
@@ -303,8 +303,8 @@ class DependencyHandler(BaseHandler):
                 if line.startswith("Requires-Dist: "):
                     t = line[len("Requires-Dist: "):]
                     if ";" in t:
-                        es = t[t.find(";") + 1].replace('"', "").replace("'", "")
-                        t = t[:t.find(";")]
+                        es = t[t.find(";") + 1:].replace('"', "").replace("'", "")
+                        t = t[:t.find(";")].strip()
                         if VersionSpecifier is None:
                             # libversion not found
                             print("Warning: could not import libversion.VersionSpecifier! Ignoring version and extra dependencies.")

--- a/lib/stashutils/wheels.py
+++ b/lib/stashutils/wheels.py
@@ -291,7 +291,17 @@ class DependencyHandler(BaseHandler):
         else:
             with open(metajsonp, "r") as fin:
                 content = json.load(fin)
-            dependencies = content.get("run_requires", [{"requires": []}])[0]["requires"]
+            # dependencies = content.get("run_requires", [{"requires": []}])[0]["requires"]
+            dependencies = []
+            for ds in content.get("run_requires", []):
+                ex = ds.get("extra", None)
+                dep = ds.get("requires", [])
+                if ex is not None:
+                    if ex != self.wheel.extra:
+                        # extra not wanted
+                        continue
+                else:
+                    dependencies.append(dep)
         self.wheel.dependencies += dependencies
 
     def read_dependencies_from_METADATA(self, p):

--- a/tests/misc/test_libversion.py
+++ b/tests/misc/test_libversion.py
@@ -28,6 +28,7 @@ class LibVersionTests(StashTestCase):
             ("tne != 7.0.0", "tne", [(operator.ne, "7.0.0")]),
             ("pkg_b (< 0.7.0", "pkg_b", [(operator.lt, "0.7.0")]),
             ("nondigitver <= 1.5.3b", "nondigitver", [(operator.le, "1.5.3b")]),
+            ("wrapt < 2, >= 1", "wrapt", [(operator.lt, "2"), (operator.ge, "1")]),
         ]
         for req, pkg, spec in to_test:
             name, ver_spec = self.stash.libversion.VersionSpecifier.parse_requirement(req)
@@ -46,6 +47,7 @@ class LibVersionTests(StashTestCase):
             ("lttest <= 2.0.0", [("2.0.0", True), ("2.0.1", False), ("3.0.0", False), ("1.0.0", True), ("1.9.0", True), ("11.0.0", False), ("1.9.2b", True)]),
             ("gttest >= 3.5.0", [("3.5.0", True), ("3.4.9", False), ("3.6.0", True), ("11.0.0", True), ("3.5.0a", False), ("1.0.0", False)]),
             ("eqstr == str", [("1.0.0", False), ("str", True), ("str2", False), ("s", False), ("99.999.99", False)]),
+            ("wrapt < 2, >= 1", [("0.0.1", False), ("1.0.0", True), ("1.5.0", True), ("2.0.0", False), ("1.9.9", True)]),
         ]
         for rs, test in to_test:
             _, ver_spec = self.stash.libversion.VersionSpecifier.parse_requirement(rs)

--- a/tests/misc/test_libversion.py
+++ b/tests/misc/test_libversion.py
@@ -21,7 +21,7 @@ class LibVersionTests(StashTestCase):
         to_test = [
             # format: (requirement_str, pkg_name, [(op1, v1), ...])
             ("test==1.2.3", "test", [(operator.eq, "1.2.3")]),
-            ("test_2 == 7.3.12", "test2", [(operator.eq, "1.2.3")]),
+            ("test_2 == 7.3.12", "test_2", [(operator.eq, "1.2.3")]),
             ("with1number == 923.1512.12412", "with1number",[(operator.eq, "923.1512.12412")]),
             ("tge >= 2.0.1", "tge", [(operator.ge, "2.0.1")]),
             ("tgt > 3.0.0", "tgt", [(operator.gt, "3.0.0")]),
@@ -36,13 +36,13 @@ class LibVersionTests(StashTestCase):
 
     def test_version_specifier_match(self):
         """test 'libversion.VersionSpecifier().match()'"""
-        to_test = {
+        to_test = [
             # format: (requirement_str, [(testversion, result)])
             ("eqtest == 1.0.0", [("1.0.0", True), ("1.0.1", False), ("1.0.0.0", False), ("11.0.0", False), ("0.1.0.0", False), ("0.9.0", False)]),
             ("lttest <= 2.0.0", [("2.0.0", True), ("2.0.1", False), ("3.0.0", False), ("1.0.0", True), ("1.9.0", True), ("11.0.0", False), ("1.9.2b", True)]),
             ("gttest >= 3.5.0", [("3.5.0", True), ("3.4.9", False), ("3.6.0", True), ("11.0.0", True), ("3.5.0a", True), ("1.0.0", False)]),
             ("eqstr == str", [("1.0.0", False), ("str", True), ("str2", False), ("s", False), ("99.999.99", False)]),
-        }
+        ]
         for rs, test in to_test:
             ver_spec = self.stash.libversion.VersionSpecifier.parse_requirement(rs)
             ts, expected = test

--- a/tests/misc/test_libversion.py
+++ b/tests/misc/test_libversion.py
@@ -27,7 +27,7 @@ class LibVersionTests(StashTestCase):
             ("tgt > 3.0.0", "tgt", [(operator.gt, "3.0.0")]),
             ("tne != 7.0.0", "tne", [(operator.ne, "7.0.0")]),
             ("pkg_b (< 0.7.0", "pkg_b", [(operator.lt, "0.7.0")]),
-            ("nondigitver <= 1.5.3b", [(operator.le, "1.5.3b")]),
+            ("nondigitver <= 1.5.3b", "nondigitver", [(operator.le, "1.5.3b")]),
         ]
         for req, pkg, spec in to_test:
             name, ver_spec = self.stash.libversion.VersionSpecifier.parse_requirement(req)
@@ -69,3 +69,71 @@ class LibVersionTests(StashTestCase):
         expected = ["1!0.5.0", "1.0.0.post1", "1.0.0", "1.0.0rc", "1.0.0b", "1.0.0a2", "1.0.0a", "1.0.0a.dev3", "1.0.0a.dev2", "1.0.0a.dev1", "0.5.0"]
         sortedres = self.stash.libversion.sort_versions(raw)
         self.assertEqual(sortedres, expected)
+
+    def test_version_parse(self):
+        """test 'libversion.Version.parse()''"""
+        to_test = [
+            # format: (s, {key_to_check: expected_value, ...})
+            ("1.2.3", {"epoch": 0, "versiontuple": (1, 2, 3), "is_postrelease": False}),
+            ("1!2.3", {"epoch": 1, "versiontuple": (2, 3), "is_devrelease": False}),
+            ("5.5.4a.post5", {"versiontuple": (5, 5, 4), "rtype": self.stash.libversion.Version.TYPE_ALPHA, "is_postrelease": True, "postrelease": 5}),
+            ("0.0.1rc5.dev7", {"versiontuple": (0, 0, 1), "rtype": self.stash.libversion.Version.TYPE_RELEASE_CANDIDATE, "subversion": 5, "is_devrelease": True, "devrelease": 7, "is_postrelease": False}),
+            ("0.8.4.post.dev", {"veriontuple": (0, 8, 4), "is_postrelease": True, "postrelease": 0, "is_devrelease": True}),
+        ]
+        for vs, ea in to_test:
+            version = self.stash.libversion.Version.parse(vs)
+            self.assertIsInstance(version, self.stash.libversion.Version)
+            for ean in ea.keys():
+                eav = ea[ean]
+                assert hasattr(version, ean)
+                self.assertEqual(getattr(version, ean), eav)
+
+    def test_version_cmp(self):
+        """test comparsion of 'libversion.Version()'-instances"""
+        to_test = [
+            # format: (vs1, op, vs2, res)
+            # testdata for general equality
+            ("1.0.0", operator.eq, "1.0.0", True),
+            ("1.0.0", operator.eq, "0!1.0.0", True),
+            ("1.0.0", operator.eq, "1!1.0.0", False),
+            ("1.0.0", operator.eq, "1.0.0.post", False),
+            ("1.0.0", operator.eq, "1.0.0a", False),
+            ("1.0.0", operator.eq, "1.0.0b", False),
+            ("1.0.0.post1", operator.eq, "1.0.0.post2", False),
+            ("1.0.0.post", operator.eq, "1.0.0.post1", True),
+            ("1.0.0.post", operator.eq, "1.0.0.dev", False),
+            # testdata for main version comparsion
+            ("1.2.3", operator.eq, "1.5.0", False),
+            ("2.0.3", operator.gt, "1.9.7", True),
+            ("1.9.7", operator.gt, "2.0.3", False),
+            ("1.9.7", operator.lt, "2.0.3", True),
+            ("1.9.7", operator.lt, "1.9.7", False),
+            ("1.9.7", operator.le, "1.9.7", True),
+            ("2.4.9", operator.gt, "11.0.5", False),
+            ("2.4.9", operator.gt, "1.0.5", True),
+            ("2.4.9", operator.gt, "2.5.1", False),
+            ("2.5.2", operator.gt, "2.5.1", True),
+            # testdata for rtype comparsion
+            ("1.0.0", operator.eq, "1.0.0a", False),
+            ("1.0.0", operator.eq, "1.0.0b", False),
+            ("1.0.0", operator.eq, "1.0.0rc", False),
+            ("1.0.0a", operator.eq, "1.0.0b", False),
+            ("1.0.0a", operator.eq, "1.0.0rc", False),
+            ("1.0.0b", operator.eq, "1.0.0rc", False),
+            ("1.0.0", operator.gt, "1.0.0rc", True),
+            ("1.0.0rc", operator.gt, "1.0.0b", True),
+            ("1.0.0b", operator.gt, "1.0.0a", True),
+            ("1.0.0", operator.gt, "1.0.0b", True),
+            ("1.0.0", operator.gt, "1.0.0a", True),
+            ("1.0.0rc", operator.gt, "1.0.0a", True),
+            # testdata for dev version comparsion
+            ("1.0.0", operator.gt, "1.0.0.dev", True),
+            ("1.0.0", operator.gt, "1.0.0.dev1000", True),
+            ("1.0.0.dev", operator.gt, "1.0.0", False),
+            ("1.0.0.dev2", operator.gt, "1.0.0.dev", True),
+        ]
+        for vs1, op, vs2, expected in to_test:
+            v1 = self.stash.libversion.Version.parse(vs1)
+            v2 = self.stash.libversion.Version.parse(vs2)
+            self.assertEqual(op(v1, v2), expected)
+

--- a/tests/misc/test_libversion.py
+++ b/tests/misc/test_libversion.py
@@ -21,7 +21,7 @@ class LibVersionTests(StashTestCase):
         to_test = [
             # format: (requirement_str, pkg_name, [(op1, v1), ...])
             ("test==1.2.3", "test", [(operator.eq, "1.2.3")]),
-            ("test_2 == 7.3.12", "test_2", [(operator.eq, "1.2.3")]),
+            ("test_2 == 7.3.12", "test_2", [(operator.eq, "7.3.12")]),
             ("with1number == 923.1512.12412", "with1number",[(operator.eq, "923.1512.12412")]),
             ("tge >= 2.0.1", "tge", [(operator.ge, "2.0.1")]),
             ("tgt > 3.0.0", "tgt", [(operator.gt, "3.0.0")]),
@@ -45,27 +45,27 @@ class LibVersionTests(StashTestCase):
         ]
         for rs, test in to_test:
             ver_spec = self.stash.libversion.VersionSpecifier.parse_requirement(rs)
-            ts, expected = test
-            result = ver_spec.match(ts)
-            self.assertEqual(result, expected)
+            for ts, expected in test:
+                result = ver_spec.match(ts)
+                self.assertEqual(result, expected)
 
     def test_sort_versions_main(self):
         """test 'libversion.sort_versions()' for main versions"""
         raw = ["1.0.0", "0.5.0", "0.6.0", "0.5.9", "11.0.3", "11.0.4", "0.1.0", "5.7.0"]
         expected = ["11.0.4", "11.0.3", "5.7.0", "1.0.0", "0.6.0", "0.5.9", "0.5.0", "0.1.0"]
-        sorted = self.stash.libversion.sort_versions(raw)
-        self.assertEqual(raw, expected)
+        sortedres = self.stash.libversion.sort_versions(raw)
+        self.assertEqual(sortedres, expected)
 
     def test_sort_versions_post(self):
         """test 'libversion.sort_versions()' for post release number"""
         raw = ["1.0.0", "1.0.0.post2", "1.0.0.post3", "1.0.0-post1", "1.0.0.post"]
         expected = ["1.0.0.post3", "1.0.0.post2", "1.0.0-post1", "1.0.0.post", "1.0.0"]
-        sorted = self.stash.libversion.sort_versions(raw)
-        self.assertEqual(raw, expected)
+        sortedres = self.stash.libversion.sort_versions(raw)
+        self.assertEqual(sortedres, expected)
 
     def test_sort_versions_type(self):
         """test 'libversion.sort_versions()' for release type"""
         raw = ["1.0.0b", "1.0.0rc", "1.0.0a", "1.0.0a2", "1.0.0", "1.0.0.post1", "1.0.0a.dev2", "1.0.0a.dev3", "1!0.5.0", "0.5.0", "1.0.0a.dev1"]
         expected = ["1!0.5.0", "1.0.0.post1", "1.0.0", "1.0.0rc", "1.0.0b", "1.0.0a2", "1.0.0a", "1.0.0a.dev3", "1.0.0a.dev2", "1.0.0a.dev1", "0.5.0"]
-        sorted = self.stash.libversion.sort_versions(raw)
-        self.assertEqual(raw, expected)
+        sortedres = self.stash.libversion.sort_versions(raw)
+        self.assertEqual(sortedres, expected)

--- a/tests/misc/test_libversion.py
+++ b/tests/misc/test_libversion.py
@@ -32,7 +32,11 @@ class LibVersionTests(StashTestCase):
         for req, pkg, spec in to_test:
             name, ver_spec = self.stash.libversion.VersionSpecifier.parse_requirement(req)
             self.assertEqual(name, pkg)
-            self.assertItemsEqual(ver_spec.specs, spec)
+            if self.stash.PY3:
+                # in py3, assertItemsEqual has been renamed to assertCountEqual
+                self.assertCountEqual(ver_spec.specs, spec)
+            else:
+                self.assertItemsEqual(ver_spec.specs, spec)
 
     def test_version_specifier_match(self):
         """test 'libversion.VersionSpecifier().match()'"""

--- a/tests/misc/test_libversion.py
+++ b/tests/misc/test_libversion.py
@@ -40,7 +40,7 @@ class LibVersionTests(StashTestCase):
             # format: (requirement_str, [(testversion, result)])
             ("eqtest == 1.0.0", [("1.0.0", True), ("1.0.1", False), ("1.0.0.0", False), ("11.0.0", False), ("0.1.0.0", False), ("0.9.0", False)]),
             ("lttest <= 2.0.0", [("2.0.0", True), ("2.0.1", False), ("3.0.0", False), ("1.0.0", True), ("1.9.0", True), ("11.0.0", False), ("1.9.2b", True)]),
-            ("gttest >= 3.5.0", [("3.5.0", True), ("3.4.9", False), ("3.6.0", True), ("11.0.0", True), ("3.5.0a", True), ("1.0.0", False)]),
+            ("gttest >= 3.5.0", [("3.5.0", True), ("3.4.9", False), ("3.6.0", True), ("11.0.0", True), ("3.5.0a", False), ("1.0.0", False)]),
             ("eqstr == str", [("1.0.0", False), ("str", True), ("str2", False), ("s", False), ("99.999.99", False)]),
         ]
         for rs, test in to_test:
@@ -78,7 +78,7 @@ class LibVersionTests(StashTestCase):
             ("1!2.3", {"epoch": 1, "versiontuple": (2, 3), "is_devrelease": False}),
             ("5.5.4a.post5", {"versiontuple": (5, 5, 4), "rtype": self.stash.libversion.Version.TYPE_ALPHA, "is_postrelease": True, "postrelease": 5}),
             ("0.0.1rc5.dev7", {"versiontuple": (0, 0, 1), "rtype": self.stash.libversion.Version.TYPE_RELEASE_CANDIDATE, "subversion": 5, "is_devrelease": True, "devrelease": 7, "is_postrelease": False}),
-            ("0.8.4.post.dev", {"veriontuple": (0, 8, 4), "is_postrelease": True, "postrelease": 0, "is_devrelease": True}),
+            ("0.8.4.post.dev", {"versiontuple": (0, 8, 4), "is_postrelease": True, "postrelease": 0, "is_devrelease": True}),
         ]
         for vs, ea in to_test:
             version = self.stash.libversion.Version.parse(vs)
@@ -100,7 +100,7 @@ class LibVersionTests(StashTestCase):
             ("1.0.0", operator.eq, "1.0.0a", False),
             ("1.0.0", operator.eq, "1.0.0b", False),
             ("1.0.0.post1", operator.eq, "1.0.0.post2", False),
-            ("1.0.0.post", operator.eq, "1.0.0.post1", True),
+            ("1.0.0.post", operator.eq, "1.0.0.post0", True),
             ("1.0.0.post", operator.eq, "1.0.0.dev", False),
             # testdata for main version comparsion
             ("1.2.3", operator.eq, "1.5.0", False),

--- a/tests/misc/test_libversion.py
+++ b/tests/misc/test_libversion.py
@@ -26,7 +26,7 @@ class LibVersionTests(StashTestCase):
             ("tge >= 2.0.1", "tge", [(operator.ge, "2.0.1")]),
             ("tgt > 3.0.0", "tgt", [(operator.gt, "3.0.0")]),
             ("tne != 7.0.0", "tne", [(operator.ne, "7.0.0")]),
-            ("pkg_b (< 0.7.0", "okg_b", [(operator.lt, "0.7.0")]),
+            ("pkg_b (< 0.7.0", "pkg_b", [(operator.lt, "0.7.0")]),
             ("nondigitver <= 1.5.3b", [(operator.le, "1.5.3b")]),
         ]
         for req, pkg, spec in to_test:
@@ -44,7 +44,7 @@ class LibVersionTests(StashTestCase):
             ("eqstr == str", [("1.0.0", False), ("str", True), ("str2", False), ("s", False), ("99.999.99", False)]),
         ]
         for rs, test in to_test:
-            ver_spec = self.stash.libversion.VersionSpecifier.parse_requirement(rs)
+            _, ver_spec = self.stash.libversion.VersionSpecifier.parse_requirement(rs)
             for ts, expected in test:
                 result = ver_spec.match(ts)
                 self.assertEqual(result, expected)

--- a/tests/misc/test_libversion.py
+++ b/tests/misc/test_libversion.py
@@ -1,0 +1,71 @@
+"""tests for libversion"""
+import operator
+
+from stash.tests.stashtest import StashTestCase
+
+
+class LibVersionTests(StashTestCase):
+    """Tests for the 'libversion' module"""
+    def test_is_loaded(self):
+        """assert that the 'libversion' module is loaded by StaSh"""
+        assert hasattr(self.stash, "libversion")
+        self.assertIsNotNone(self.stash)
+
+    def test_import(self):
+        """test that the libversion module can be imported"""
+        # $STASH_ROOT/lib/ *should* be in sys.path, thus an import should be possible
+        import libversion
+
+    def test_version_specifier_parse(self):
+        """test 'libversion.VersionSpecifier.parse_requirement()'"""
+        to_test = [
+            # format: (requirement_str, pkg_name, [(op1, v1), ...])
+            ("test==1.2.3", "test", [(operator.eq, "1.2.3")]),
+            ("test_2 == 7.3.12", "test2", [(operator.eq, "1.2.3")]),
+            ("with1number == 923.1512.12412", "with1number",[(operator.eq, "923.1512.12412")]),
+            ("tge >= 2.0.1", "tge", [(operator.ge, "2.0.1")]),
+            ("tgt > 3.0.0", "tgt", [(operator.gt, "3.0.0")]),
+            ("tne != 7.0.0", "tne", [(operator.ne, "7.0.0")]),
+            ("pkg_b (< 0.7.0", "okg_b", [(operator.lt, "0.7.0")]),
+            ("nondigitver <= 1.5.3b", [(operator.le, "1.5.3b")]),
+        ]
+        for req, pkg, spec in to_test:
+            name, ver_spec = self.stash.libversion.VersionSpecifier.parse_requirement(req)
+            self.assertEqual(name, pkg)
+            self.assertItemsEqual(ver_spec.specs, spec)
+
+    def test_version_specifier_match(self):
+        """test 'libversion.VersionSpecifier().match()'"""
+        to_test = {
+            # format: (requirement_str, [(testversion, result)])
+            ("eqtest == 1.0.0", [("1.0.0", True), ("1.0.1", False), ("1.0.0.0", False), ("11.0.0", False), ("0.1.0.0", False), ("0.9.0", False)]),
+            ("lttest <= 2.0.0", [("2.0.0", True), ("2.0.1", False), ("3.0.0", False), ("1.0.0", True), ("1.9.0", True), ("11.0.0", False), ("1.9.2b", True)]),
+            ("gttest >= 3.5.0", [("3.5.0", True), ("3.4.9", False), ("3.6.0", True), ("11.0.0", True), ("3.5.0a", True), ("1.0.0", False)]),
+            ("eqstr == str", [("1.0.0", False), ("str", True), ("str2", False), ("s", False), ("99.999.99", False)]),
+        }
+        for rs, test in to_test:
+            ver_spec = self.stash.libversion.VersionSpecifier.parse_requirement(rs)
+            ts, expected = test
+            result = ver_spec.match(ts)
+            self.assertEqual(result, expected)
+
+    def test_sort_versions_main(self):
+        """test 'libversion.sort_versions()' for main versions"""
+        raw = ["1.0.0", "0.5.0", "0.6.0", "0.5.9", "11.0.3", "11.0.4", "0.1.0", "5.7.0"]
+        expected = ["11.0.4", "11.0.3", "5.7.0", "1.0.0", "0.6.0", "0.5.9", "0.5.0", "0.1.0"]
+        sorted = self.stash.libversion.sort_versions(raw)
+        self.assertEqual(raw, expected)
+
+    def test_sort_versions_post(self):
+        """test 'libversion.sort_versions()' for post release number"""
+        raw = ["1.0.0", "1.0.0.post2", "1.0.0.post3", "1.0.0-post1", "1.0.0.post"]
+        expected = ["1.0.0.post3", "1.0.0.post2", "1.0.0-post1", "1.0.0.post", "1.0.0"]
+        sorted = self.stash.libversion.sort_versions(raw)
+        self.assertEqual(raw, expected)
+
+    def test_sort_versions_type(self):
+        """test 'libversion.sort_versions()' for release type"""
+        raw = ["1.0.0b", "1.0.0rc", "1.0.0a", "1.0.0a2", "1.0.0", "1.0.0.post1", "1.0.0a.dev2", "1.0.0a.dev3", "1!0.5.0", "0.5.0", "1.0.0a.dev1"]
+        expected = ["1!0.5.0", "1.0.0.post1", "1.0.0", "1.0.0rc", "1.0.0b", "1.0.0a2", "1.0.0a", "1.0.0a.dev3", "1.0.0a.dev2", "1.0.0a.dev1", "0.5.0"]
+        sorted = self.stash.libversion.sort_versions(raw)
+        self.assertEqual(raw, expected)

--- a/tests/pip/test_pip.py
+++ b/tests/pip/test_pip.py
@@ -109,6 +109,7 @@ class PipTests(StashTestCase):
             raise AssertionError("Could not import installed module: " + repr(e))
 
     @requires_network
+    @expected_failure_on_py3
     def test_install_pypi_complex_1(self):
         """test 'pip install <pypi_package>' with a complex package."""
         output = self.run_command("pip --verbose install twisted", exitcode=0)

--- a/tests/pip/test_pip.py
+++ b/tests/pip/test_pip.py
@@ -109,7 +109,6 @@ class PipTests(StashTestCase):
             raise AssertionError("Could not import installed module: " + repr(e))
 
     @requires_network
-    @expected_failure_on_py3
     def test_install_pypi_complex_1(self):
         """test 'pip install <pypi_package>' with a complex package."""
         output = self.run_command("pip --verbose install twisted", exitcode=0)


### PR DESCRIPTION
Hi,
In the last few weeks,  I have been on a successful hunting bugs in `pip`.
These improvements mainly target version-related behavior. I also fixed the dependency installation for `gh`.

- **general:**
    - version bump to `0.7.2`
- `pip`:
    - **improvement:** add the `--only-binary`, `--prefer-binary` and `--no-binary` arguments to `pip`. These arguments allow the use to specifically set preference between source and wheel releases. Suggested by @jsbain in [this forum thread](https://forum.omz-software.com/topic/5381/stash-alternatives-for-pip/2)
    - **improvement**: more verbose output. Also more normal output (e.g. which packages requires a dependency).
    - **improvement/bugfix:** `pip` now respects `python_requires`. This should greatly improve py2/py3 compatibilty for `pip`.
    - **bugfix:** `pip` will now attempt to use the newest version matching the requirements (*old behavior: use first matching version in the order returned by pypi (e.g. `0.1.0` for `<=2.0.0`*))
    - **improvement:** split version logic into a seperate file (`$STASH_ROOT/lib/libversion.py`.
    - more bugfixes/improvements listed in the section for `libversion`.
- `stashutils.wheels:`:
    - **improvement:** support for `wheel version 1.9`-wheels
    - **bugfix:** fix bug which sometimes installed *extra*-requiremnts instead of the *normal* requirements.
    - **bugfix:** fix verbosity always on
- `libversion`:
    - contains version logic from `pip`, with various improvements and bugfixes
    - **improvement:** `PEP440`-version parsing
    - **bugfix:** `VersionSpecifier` now correctly parses dependencies/requirements containing multiple requirements (e.g. `wrapt >= 1.0.0, < 2.0.0`)
    - **improvement:** the `VersionSpecifier` now has a `.match()` method for checking version requirements.
- `gh`:
    - **improvement/bugfix:** improve general py3 compatibility (fix #340). Further testing may be needed.
    - **improvement:** now use `pip` for dependency installation
- **tests:**
    - tests for `libversion`.
    - tests for the new `pip`-arguments