### PR TITLE
Fix encoding error for executing setup.py

### DIFF
--- a/bin/crypt.py
+++ b/bin/crypt.py
@@ -74,8 +74,8 @@ if __name__ == '__main__':
     args = ap.parse_args()
     crypt = Crypt(args.infile, args.outfile)
     if args.decrypt:
-        crypt.aes_decrypt(args.key)
+        crypt.aes_decrypt(args.key.encode())
     else:
         nk = crypt.aes_encrypt(args.key)
         if args.key is None:
-            print("Key: %s" % nk)
+            print("Key: %s" % nk.decode())

--- a/bin/pip.py
+++ b/bin/pip.py
@@ -780,9 +780,12 @@ if __name__ == "__main__":
         """
         # with codecs.open(filename, mode="r", encoding="UTF-8") as ins:
         #    s = ins.read()
-        with open(filename, "r") as ins:
-            s = ins.read()
-        tree = ast.parse(s, filename=filename, mode='exec')
+        with open(filename, "rb") as ins:
+            tree = ast.parse(
+                ins.read(),
+                filename=filename,
+                mode='exec'
+            )
         ArchiveFileInstaller.SetupTransformer().visit(tree)
         return tree
 


### PR DESCRIPTION
This commit fixes #381, where setup.py may have Unicode symbols. In this case, setup.py is passed as a bytestring to avoid guessing the encoding of setup.py (or to assume it is ASCII).