### PR TITLE
Fix curl not downloading binary blobs

### DIFF
--- a/bin/curl.py
+++ b/bin/curl.py
@@ -75,14 +75,14 @@ def main(args):
         return
 
     if ns.output_file:
-        with open(ns.output_file, 'w') as outs:
-            outs.write(r.text)
+        with open(ns.output_file, 'wb') as outs:
+            outs.write(r.content)
     elif ns.remote_name:
         # get basename of url
         url_path = urlparse(url).path
         filename = url_path.split('/')[-1]
-        with open(filename, 'w') as outs:
-            outs.write(r.text)
+        with open(filename, 'wb') as outs:
+            outs.write(r.content)
     else:
         print(r.text)
 

--- a/data/pip_blacklist.json
+++ b/data/pip_blacklist.json
@@ -1,5 +1,5 @@
 {
-"reasons": {
+  "reasons": {
     "C": "This package uses C-Code, which can not be compiled by StaSh.",
     "unknown": "Reason unknown.",
     "is_stash": "The name of the package conflicts with StaSh.",
@@ -8,17 +8,62 @@
     "processes": "This package requires process interaction, which is not possible on iOS",
     "bundled": "This package is already bundled with Pythonista",
     "incompatible_dependency": "This package has one or more dependencies which are incompatible with Pythonista."
-},
-"blacklist": {
-    "stash": ["is_stash", true, null],
-    "pip": ["is_pip", true, null],
-    "selenium": ["processes", true, null],
-    "matplotlib": ["bundled", false, null],
-    "mypy": ["C", true, null],
-    "eventlet": ["C", true, null],
-    "scipy": ["C", true, null],
-    "tensorflow": ["C", true, null],
-    "pyobjc": ["C", true, null],
-    "pyttsx3": ["incompatible_dependency", true, null]
-}
+  },
+  "blacklist": {
+    "stash": [
+      "is_stash",
+      true,
+      null
+    ],
+    "pip": [
+      "is_pip",
+      true,
+      null
+    ],
+    "selenium": [
+      "processes",
+      true,
+      null
+    ],
+    "matplotlib": [
+      "bundled",
+      false,
+      null
+    ],
+    "mypy": [
+      "C",
+      true,
+      null
+    ],
+    "eventlet": [
+      "C",
+      true,
+      null
+    ],
+    "scipy": [
+      "C",
+      true,
+      null
+    ],
+    "tensorflow": [
+      "C",
+      true,
+      null
+    ],
+    "pyobjc": [
+      "C",
+      true,
+      null
+    ],
+    "pyttsx3": [
+      "incompatible_dependency",
+      true,
+      null
+    ],
+    "futures": [
+      "incompatible_dependency",
+      false,
+      null
+    ]
+  }
 }

--- a/data/pip_blacklist.json
+++ b/data/pip_blacklist.json
@@ -1,5 +1,5 @@
 {
-  "reasons": {
+"reasons": {
     "C": "This package uses C-Code, which can not be compiled by StaSh.",
     "unknown": "Reason unknown.",
     "is_stash": "The name of the package conflicts with StaSh.",
@@ -7,63 +7,20 @@
     "lowlevel_os": "This package uses (relatively) low-level OS functions, which can not be used with Pythonista.",
     "processes": "This package requires process interaction, which is not possible on iOS",
     "bundled": "This package is already bundled with Pythonista",
-    "incompatible_dependency": "This package has one or more dependencies which are incompatible with Pythonista."
-  },
-  "blacklist": {
-    "stash": [
-      "is_stash",
-      true,
-      null
-    ],
-    "pip": [
-      "is_pip",
-      true,
-      null
-    ],
-    "selenium": [
-      "processes",
-      true,
-      null
-    ],
-    "matplotlib": [
-      "bundled",
-      false,
-      null
-    ],
-    "mypy": [
-      "C",
-      true,
-      null
-    ],
-    "eventlet": [
-      "C",
-      true,
-      null
-    ],
-    "scipy": [
-      "C",
-      true,
-      null
-    ],
-    "tensorflow": [
-      "C",
-      true,
-      null
-    ],
-    "pyobjc": [
-      "C",
-      true,
-      null
-    ],
-    "pyttsx3": [
-      "incompatible_dependency",
-      true,
-      null
-    ],
-    "futures": [
-      "incompatible_dependency",
-      false,
-      null
-    ]
-  }
+    "incompatible_dependency": "This package has one or more dependencies which are incompatible with Pythonista.",
+    "bugged": "Installation of this packages is currently critically bugged."
+},
+"blacklist": {
+    "stash": ["is_stash", true, null],
+    "pip": ["is_pip", true, null],
+    "selenium": ["processes", true, null],
+    "matplotlib": ["bundled", false, null],
+    "mypy": ["C", true, null],
+    "eventlet": ["C", true, null],
+    "scipy": ["C", true, null],
+    "tensorflow": ["C", true, null],
+    "pyobjc": ["C", true, null],
+    "pyttsx3": ["incompatible_dependency", true, null],
+    "futures": ["bugged", true, null]
+}
 }


### PR DESCRIPTION
Content to be downloaded may contain raw bytes, so it is best to write it as bytes directly to the file (without decoding).