### PR TITLE
Add ‘regex’ module to blacklist

### DIFF
--- a/data/pip_blacklist.json
+++ b/data/pip_blacklist.json
@@ -21,6 +21,7 @@
     "tensorflow": ["C", true, null],
     "pyobjc": ["C", true, null],
     "pyttsx3": ["incompatible_dependency", true, null],
-    "futures": ["bugged", true, null]
+    "futures": ["bugged", true, null],
+    "regex": ["C", true, null],
 }
 }


### PR DESCRIPTION
The ‘regex’ module uses C extensions, which can’t be compiled on Pythonista.
Also, because ‘regex’ is a dependency of the ‘black’ code formatter, it seems we can’t use black on Pythonista :(
```
[~/Documents]λ pip install black
Querying PyPI ... 
Downloading package ...
Opening: https://files.pythonhosted.org/packages/fd/bb/ad34bbc93d1bea3de086d7c59e528d4a503ac8fe318bd1fa48605584c3d2/black-19.10b0-py36-none-any.whl

Save as: /private/var/mobile/Containers/Data/Application/B003D520-C2B7-4AB4-85BB-A3249C3C1D78/tmp//black-19.10b0-py36-none-any.whl (97525 bytes)
[====================] 100.00% | 95.2KiB          
Installing wheel: black-19.10b0-py36-none-any.whl...
Package installed: black
Installing dependency: click[('>=', '6.5')] (required by: black)
Querying PyPI ... 
Downloading package ...
Opening: https://files.pythonhosted.org/packages/dd/c0/4d8f43a9b16e289f36478422031b8a63b54b6ac3b1ba605d602f10dd54d6/click-7.1.1-py2.py3-none-any.whl

Save as: /private/var/mobile/Containers/Data/Application/B003D520-C2B7-4AB4-85BB-A3249C3C1D78/tmp//click-7.1.1-py2.py3-none-any.whl (82818 bytes)
[====================] 100.00% | 80.9KiB          
Installing wheel: click-7.1.1-py2.py3-none-any.whl...
Package installed: click
Installing dependency: attrs[('>=', '18.1.0')] (required by: black)
Querying PyPI ... 
Downloading package ...
Opening: https://files.pythonhosted.org/packages/a2/db/4313ab3be961f7a763066401fb77f7748373b6094076ae2bda2806988af6/attrs-19.3.0-py2.py3-none-any.whl

Save as: /private/var/mobile/Containers/Data/Application/B003D520-C2B7-4AB4-85BB-A3249C3C1D78/tmp//attrs-19.3.0-py2.py3-none-any.whl (39472 bytes)
[====================] 100.00% | 38.5KiB          
Installing wheel: attrs-19.3.0-py2.py3-none-any.whl...
Package installed: attrs
Dependency already installed: appdirs
Installing dependency: toml[('>=', '0.9.4')] (required by: black)
Querying PyPI ... 
Downloading package ...
Opening: https://files.pythonhosted.org/packages/a2/12/ced7105d2de62fa7c8fb5fce92cc4ce66b57c95fb875e9318dba7f8c5db0/toml-0.10.0-py2.py3-none-any.whl

Save as: /private/var/mobile/Containers/Data/Application/B003D520-C2B7-4AB4-85BB-A3249C3C1D78/tmp//toml-0.10.0-py2.py3-none-any.whl (25796 bytes)
[====================] 100.00% | 25.2KiB          
Installing wheel: toml-0.10.0-py2.py3-none-any.whl...
Package installed: toml
Installing dependency: typed-ast[('>=', '1.4.0')] (required by: black)
Querying PyPI ... 
Downloading package ...
Opening: https://files.pythonhosted.org/packages/18/09/b6a6b14bb8c5ec4a24fe0cf0160aa0b784fd55a6fd7f8da602197c5c461e/typed_ast-1.4.1.tar.gz

Save as: /private/var/mobile/Containers/Data/Application/B003D520-C2B7-4AB4-85BB-A3249C3C1D78/tmp//typed_ast-1.4.1.tar.gz (208587 bytes)
[====================] 100.00% | 203.7KiB          
Extracting archive file ...
Archive extracted.
Running setup file ...
WARNING: Extension modules are skipped: [<__main__.OmniClass object at 0x114607a90>, <__main__.OmniClass object at 0x114607748>]
Package installed: typed-ast
Installing dependency: regex (required by: black)
Querying PyPI ... 
Downloading package ...
Opening: https://files.pythonhosted.org/packages/4c/e7/eee73c42c1193fecc0e91361a163cbb8dfbea62c3db7618ad986e5b43a14/regex-2020.4.4.tar.gz

Save as: /private/var/mobile/Containers/Data/Application/B003D520-C2B7-4AB4-85BB-A3249C3C1D78/tmp//regex-2020.4.4.tar.gz (695848 bytes)
[====================] 100.00% | 679.5KiB          
Extracting archive file ...
Archive extracted.
Running setup file ...
WARNING: Extension modules are skipped: [<__main__.OmniClass object at 0x1155ceac8>]
PipError('cannot locate source folder/file: /private/var/mobile/Containers/Data/Application/B003D520-C2B7-4AB4-85BB-A3249C3C1D78/tmp/976644fe2bbc453c88d8114baf663f5a/regex-2020.4.4/regex.py',)
Failed to run setup.py
Fall back to directory guessing ...
Error: Cannot locate packages. Manual installation required.
```