### PR TITLE
Add gevent and grequests to blacklist

### DIFF
--- a/data/pip_blacklist.json
+++ b/data/pip_blacklist.json
@@ -22,6 +22,8 @@
     "pyobjc": ["C", true, null],
     "pyttsx3": ["incompatible_dependency", true, null],
     "futures": ["bugged", true, null],
-    "regex": ["C", true, null]
+    "regex": ["C", true, null],
+    "gevent": ["C", true, null],
+    "grequests": ["incompatible_dependency", true, null]
 }
 }


### PR DESCRIPTION
Fix for issue #407 (gevent uses c code, grequests uses gevent as a dependency)