### PR TITLE
Fixed rm.py to remove links as well

### DIFF
--- a/bin/rm.py
+++ b/bin/rm.py
@@ -71,7 +71,8 @@ def main(args):
             return True
 
     for path in ns.paths:
-        if os.path.isfile(path):
+        if (os.path.isfile(path) or
+            os.path.islink(path)):
             if prompt(path):
                 try:
                     os.remove(path)


### PR DESCRIPTION
In rm.py there where checks for isfile(...) and isdir(...) but none for islink(...) leading to problems trying to use rm.py to delete a link.