### PR TITLE
Added Eclipse meta files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,11 @@ target/
 # IDE
 .idea
 
+# Eclipse
+.project
+.settings/
+.pydevproject
+
 # Vim
 *.swp
 


### PR DESCRIPTION
Using eclipse for development and debugging, the files .project, .pydevproject and the directory .settings is added to the root of the project. To not have those distributed with the project files, I added according lines to .gitignore.