### PR TITLE
fix: Missing comma in `UNWANTED_FILES`

### DIFF
--- a/getstash.py
+++ b/getstash.py
@@ -29,7 +29,7 @@ UNWANTED_FILES = [
         'bin/pythonista.py',
         'bin/cls.py',
         'stash.py',
-        'lib/librunner.py'
+        'lib/librunner.py',
         'system/shui.py',
         'system/shterminal.py',
         'system/dummyui.py',


### PR DESCRIPTION
* This comma has been most probably been left out unintentionally, leading to string concatenation between the two consecutive lines. This issue has been found automatically using a regular expression.