### PR TITLE
patch wheels to take care of additional requirements

### DIFF
--- a/lib/libversion.py
+++ b/lib/libversion.py
@@ -323,6 +323,14 @@ class VersionSpecifier(object):
                 extras = []
             else:
                 extras = extra_s.split(",")
+        elif "[" in name:
+            si = name.find("[")
+            extra_s = name[si + 1:-1]
+            name = name[:si]
+            if len(extra_s) == 0:
+                extras = []
+            else:
+                extras = extra_s.split(",") 
         else:
             extras = []
         splitted = specs_s.split(",")

--- a/lib/stashutils/wheels.py
+++ b/lib/stashutils/wheels.py
@@ -361,13 +361,13 @@ class DependencyHandler(BaseHandler):
                                     if self.verbose:
                                         print("Adding dependencies for extras...")
                             elif rq == "platform_python_implementation":
-                                if not rq == platform.python_implementation():
+                                if not v.match(platform.python_implementation()):
                                     break
                             elif rq == "platform_system":
-                                if not rq == platform.system():
+                                if v.match(platform.system()):
                                     break
                             elif rq == "sys_platform":
-                                if not rq == sys.platform:
+                                if not v.match(sys.platform):
                                     break
                             else:
                                 # unknown requirement for dependency


### PR DESCRIPTION
In most cases wheels have additional requirements like `brotli; platform_python_implementation == 'CPython' and extra == 'brotli'`.

My changes take care about that. In addition checking for `platform_python_implementation`, `platform_system` and `sys_platform`.

Next patch `libversion` to take care of wildcard version match like `1.*`