### PR TITLE
Deprecate py2

### DIFF
--- a/core.py
+++ b/core.py
@@ -5,7 +5,7 @@ StaSh - Pythonista Shell
 https://github.com/ywangd/stash
 """
 
-__version__ = '0.7.4'
+__version__ = '0.8.0'
 
 import imp as pyimp  # rename to avoid name conflict with objc_util
 import logging

--- a/getstash.py
+++ b/getstash.py
@@ -1,3 +1,8 @@
+"""
+StaSh install script. Also used for updates.
+
+IMPORTANT: ensure we maintain py2 and py3 compatibility in this file!
+"""
 from __future__ import print_function
 import os
 import shutil
@@ -18,6 +23,8 @@ BASE_DIR = os.path.expanduser('~')
 DEFAULT_INSTALL_DIR = os.path.join(BASE_DIR, 'Documents/site-packages/stash')
 DEFAULT_PTI_PATH = os.path.join(DEFAULT_INSTALL_DIR, "bin", "ptinstaller.py")
 IN_PYTHONISTA = sys.executable.find('Pythonista') >= 0
+PY2_COMPATIBLE = True
+PY3_COMPATIBLE = True
 UNWANTED_FILES = [
         'getstash.py',
         'run_tests.py',
@@ -41,6 +48,26 @@ class DownloadError(Exception):
     Exception indicating a problem with a download.
     """
     pass
+
+
+class IncompatibleVersion(Exception):
+    """
+    Exception raised when a version is incompatible.
+    """
+    pass
+
+
+def raise_for_compatibility():
+    """
+    Check if this version of stash is compatible with this pythonista/... version, raising an exception if not.
+
+    While I'd prefer to just return True/False, raising an Exception allows us to convey
+    more info via the exception message.
+    """
+    if sys.version_info[0] == 2 and not PY2_COMPATIBLE:
+        raise IncompatibleVersion("Not compatible with python2! Try using stash<=0.7.4!")
+    elif sys.version_info[0] == 3 and not PY3_COMPATIBLE:
+        raise IncompatibleVersion("Not compatible with python3!")
 
 
 def download_stash(repo=DEFAULT_REPO, branch=DEFAULT_BRANCH, outpath=TEMP_ZIPFILE, verbose=False):
@@ -280,6 +307,15 @@ def main(defs={}):
     else:
         dist = force_dist
     
+    # check compatiblity
+    try:
+        raise_for_compatibility()
+    except IncompatibleVersion as e:
+        # inform user, then abort
+        print("Installation aborted. The version of StaSh you are trying to install is incompatible!")
+        print(e)
+        return False
+
     if dist.lower() == "pythonista":
         if install_path is None:
             install_path = DEFAULT_INSTALL_DIR

--- a/getstash.py
+++ b/getstash.py
@@ -23,7 +23,7 @@ BASE_DIR = os.path.expanduser('~')
 DEFAULT_INSTALL_DIR = os.path.join(BASE_DIR, 'Documents/site-packages/stash')
 DEFAULT_PTI_PATH = os.path.join(DEFAULT_INSTALL_DIR, "bin", "ptinstaller.py")
 IN_PYTHONISTA = sys.executable.find('Pythonista') >= 0
-PY2_COMPATIBLE = True
+PY2_COMPATIBLE = False
 PY3_COMPATIBLE = True
 UNWANTED_FILES = [
         'getstash.py',

--- a/getstash.py
+++ b/getstash.py
@@ -314,7 +314,7 @@ def main(defs={}):
         # inform user, then abort
         print("Installation aborted. The version of StaSh you are trying to install is incompatible!")
         print(e)
-        return False
+        sys.exit(1)
 
     if dist.lower() == "pythonista":
         if install_path is None:


### PR DESCRIPTION
WIth the newest pythonista version dropping py2 completely, It's time to move on an deprecate py2. (Goodbye python 2.7, you were my one true love).

This PR bumps the StaSh version to `0.8.0` and updates the `getstash`-script to prevent upgrades on py2 to versions `>0.7.4`. Technically, semantic versioning would require us to increment the major version due to breaking changes, but do we really have enough py3 compatibility to justify version `1.0.0`?