### PR TITLE
Replace Thread.isAlive() with Thread.is_alive() AGAIN

### DIFF
--- a/system/shthreads.py
+++ b/system/shthreads.py
@@ -255,13 +255,13 @@ class ShBaseThread(threading.Thread):
         Status of the thread. Created, Started or Stopped.
         """
         # STATES
-        # isAlive() | self.ident  | Meaning
-        # ----------+-------------+--------
-        # False     |     None    | created
-        # False     | not None    | stopped
-        # True      |     None    | impossible
-        # True      | not None    | running
-        if self.isAlive():
+        # is_alive() | self.ident  | Meaning
+        # -----------+-------------+--------
+        # False      |     None    | created
+        # False      | not None    | stopped
+        # True       |     None    | impossible
+        # True       | not None    | running
+        if self.is_alive():
             return self.STARTED
         elif (not self.is_alive()) and (self.ident is not None):
             return self.STOPPED

--- a/system/shui/pythonista_ui.py
+++ b/system/shui/pythonista_ui.py
@@ -894,7 +894,7 @@ class ShSequentialRenderer(ShBaseSequentialRenderer):
                 self.render_thread.cancel()
             self._render()
         else:  # delayed rendering
-            if self.render_thread is None or not self.render_thread.isAlive():
+            if self.render_thread is None or not self.render_thread.is_alive():
                 self.render_thread = sh_delay(self._render, self.RENDER_INTERVAL)
             # Do nothing if there is already a delayed rendering thread waiting
 


### PR DESCRIPTION
`Thread.is_alive()` was added in ___Python 2.6___ so we can change `.isAlive()` to `.is_alive()` everywhere to be compatible with all versions of Pythonista.
* https://docs.python.org/2/library/threading.html#threading.Thread.is_alive
* https://github.com/ywangd/stash/pull/463#discussion_r1126007645