### PR TITLE
Fix for #484: module 'plistlib' has no attribute 'readPlist'

### DIFF
--- a/system/shcommon.py
+++ b/system/shcommon.py
@@ -17,7 +17,7 @@ IN_PYTHONISTA = sys.executable.find('Pythonista') >= 0
 if IN_PYTHONISTA:
     import plistlib
 
-    with open(os.path.join(os.path.dirname(sys.executable), 'Info.plist'), 'rb') as fp :
+    with open(os.path.join(os.path.dirname(sys.executable), 'Info.plist'), 'rb') as fp:
         _properties = plistlib.loads(fp.read())
     PYTHONISTA_VERSION = _properties['CFBundleShortVersionString']
     PYTHONISTA_VERSION_LONG = _properties['CFBundleVersion']

--- a/system/shcommon.py
+++ b/system/shcommon.py
@@ -18,7 +18,7 @@ if IN_PYTHONISTA:
     import plistlib
 
     with open(os.path.join(os.path.dirname(sys.executable), 'Info.plist'), 'rb') as fp :
-        _properties = = plistlib.loads(fp.read())
+        _properties = plistlib.loads(fp.read())
     PYTHONISTA_VERSION = _properties['CFBundleShortVersionString']
     PYTHONISTA_VERSION_LONG = _properties['CFBundleVersion']
 

--- a/system/shcommon.py
+++ b/system/shcommon.py
@@ -17,7 +17,8 @@ IN_PYTHONISTA = sys.executable.find('Pythonista') >= 0
 if IN_PYTHONISTA:
     import plistlib
 
-    _properties = plistlib.readPlist(os.path.join(os.path.dirname(sys.executable), 'Info.plist'))
+    with open(os.path.join(os.path.dirname(sys.executable), 'Info.plist'), 'rb') as fp :
+        _properties = = plistlib.loads(fp.read())
     PYTHONISTA_VERSION = _properties['CFBundleShortVersionString']
     PYTHONISTA_VERSION_LONG = _properties['CFBundleVersion']
 

--- a/system/shui/pythonista_ui.py
+++ b/system/shui/pythonista_ui.py
@@ -894,7 +894,7 @@ class ShSequentialRenderer(ShBaseSequentialRenderer):
                 self.render_thread.cancel()
             self._render()
         else:  # delayed rendering
-            if self.render_thread is None or not self.render_thread.isAlive():
+            if self.render_thread is None or not self.render_thread.is_alive():
                 self.render_thread = sh_delay(self._render, self.RENDER_INTERVAL)
             # Do nothing if there is already a delayed rendering thread waiting
 


### PR DESCRIPTION
Pythonista 3 was recently upgraded to python3.10. This fix mirigates plist.py:8: DeprecationWarning: The readPlist function is deprecated, use load() instead pl=plistlib.readPlist(fileName)