### PR TITLE
Avoid the KeyboardInterrupt error in Pythonista 3.4

### DIFF
--- a/launch_stash.py
+++ b/launch_stash.py
@@ -4,6 +4,7 @@ Launch StaSh in a more flexible and reliable way.
 """
 import sys
 import argparse
+sys.exit = sys._exit
 
 module_names = (
     'stash',


### PR DESCRIPTION
Avoid the KeyboardInterrupt error after each command, and make sh file work correctly.