### PR TITLE
[WIP/untested] Add py2-compatibility guard

### DIFF
--- a/bin/selfupdate.py
+++ b/bin/selfupdate.py
@@ -19,7 +19,15 @@ from argparse import ArgumentParser
 _stash = globals()['_stash']
 
 URL_BASE = 'https://raw.githubusercontent.com/{owner}/stash'
-
+# the py2 compatibility guard to ensure py2 users don't update to an incompatible version
+# NOTE: for now, this behavior is present in both selfupdate and getstash
+# this is because the getstash script is taken from the target branch
+# and we may not always want to keep getstash py2 compatible. Thus, we replicate
+# this guard here, so that after some time hopefully nearly everyone who still uses
+# py2 has upgraded to this branch and can in the future rely on this guard instead
+# of the guard in getstash.
+PY2_BRANCH = 'py2'
+IS_PY2 = (sys.version_info[0] == 2)
 
 class UpdateError(Exception):
     pass
@@ -80,6 +88,11 @@ def main(args):
     else:
         owner, branch = 'ywangd', 'master'
         print('Invalid target {}, using default {}:{}'.format(target, owner, branch))
+
+    if IS_PY2:
+        print('Py2 detected, forcing branch to py2 legacy branch')
+        branch = PY2_BRANCH
+        # TODO: perhaps allow a way to keep branch selection for py2
 
     print(_stash.text_style('Running selfupdate ...', {'color': 'yellow', 'traits': ['bold']}))
     print(u'%s: %s:%s' % (_stash.text_bold('Target'), owner, branch))

--- a/getstash.py
+++ b/getstash.py
@@ -1,3 +1,8 @@
+"""
+StaSh install script.
+
+IMPORTANT: keep this both py2 and py3 compatible (for now)
+"""
 from __future__ import print_function
 import os
 import shutil
@@ -9,6 +14,8 @@ import time
 
 DEFAULT_REPO = "ywangd"
 DEFAULT_BRANCH = "master"
+PY2_BRANCH = "py2"
+IS_PY2 = (sys.version_info[0] == 2)
 TMPDIR = os.environ.get('TMPDIR', os.environ.get('TMP'))
 URL_TEMPLATE = 'https://github.com/{}/stash/archive/{}.zip'
 TEMP_ZIPFILE = os.path.join(TMPDIR, 'StaSh.zip')
@@ -270,6 +277,11 @@ def main(defs={}):
     zippath = defs.get("_zippath", None)                     # alternate path of zipfile to use
     dryrun = defs.get("_dryrun", None)                       # do not do anything if True
     asuser = defs.get("_asuser", None)                       # install as user if True
+
+    # py2 compatibility guard - always update to py2 branch if running on py2
+    if IS_PY2:
+        print('Running under py2, forcing update/install from py2 branch.')
+        branch = PY2_BRANCH
     
     # find out which install to use
     if force_dist is None:


### PR DESCRIPTION
I haven't yet had the chance to test this out (need to get a working pythonista app again first), but these changes should add a guard to prevent py2 users from updating to an incompatible branch.
I've created the `py2` branch as a legacy branch that will hold the last/latest py2 compatible version. This PR ensures that both `selfupdate.py` and `getstash.py` will only update to this branch when running StaSh via py2.

**TODO:**

- [ ] rebase these changes on the current `master` branch.
- [ ] actually test these changes
- [ ] change PR to target dev instead (may require reconciliation of master and dev branches)
- [ ] Also include these changes in the `py2` branch.