### PR TITLE
Fix re.sub() DeprecationWarning

### DIFF
--- a/lib/stashutils/wheels.py
+++ b/lib/stashutils/wheels.py
@@ -64,7 +64,7 @@ def escape_filename_component(fragment):
     """
     Escape a component of the filename as specified in PEP 427.
     """
-    return re.sub(r"[^\w\d.]+", "_", fragment, re.UNICODE)
+    return re.sub(r"[^\w\d.]+", "_", fragment, flags=re.UNICODE)
 
 
 def generate_filename(


### PR DESCRIPTION
`pytest` generates ___DeprecationWarning: 'count' is passed as positional argument___ because `re.UNICODE` is being sent as `count` instead of `flags` in [`re.sub()`](https://docs.python.org/3/library/re.html#re.sub).
```diff
-    return re.sub(r"[^\w\d.]+", "_", fragment, re.UNICODE)
+    return re.sub(r"[^\w\d.]+", "_", fragment, flags=re.UNICODE)
```
https://docs.astral.sh/ruff/rules/re-sub-positional-args